### PR TITLE
Fix typo in gen: sepc_template -> spec_template

### DIFF
--- a/resources/gen-spec.py
+++ b/resources/gen-spec.py
@@ -39,7 +39,7 @@ def inherit_get(config, section):
                 del merged[key]
         return merged
 
-def gen(sepc_template, rule_template, spec_ini, spec_name, rule_name_list):
+def gen(spec_template, rule_template, spec_ini, spec_name, rule_name_list):
     spec_config = configparser.ConfigParser(comment_prefixes=(';'))
     spec_config.read(spec_ini)
     if 'pgm' not in spec_config:


### PR DESCRIPTION
In gen(), the parameter sepc_template is a misspelling of spec_template. It happens to work because the value of the global spec_template (which is passed to gen() as sepc_template) on line 77 is used instead inside of gen().