### PR TITLE
Profiling and performance optimizations for K

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -353,4 +353,4 @@ test_files:=$(wildcard specs/*/*-spec.k)
 test: $(test_files:=.test)
 
 specs/%-spec.k.test: specs/%-spec.k
-	$(TEST) $< --z3-impl-timeout 500
+	$(TEST) $< --z3-impl-timeout 500 --verbose


### PR DESCRIPTION
.build/k: 195c57a78968579e09926e5a4b6ec24626ed612e
Also activated --verbose on Jenkins.