### PR TITLE
add explicit import

### DIFF
--- a/resources/lemmas.md
+++ b/resources/lemmas.md
@@ -6,6 +6,7 @@ requires "evm.k"
 
 module LEMMAS
     imports EVM
+    imports K-REFLECTION
 ```
 
 ### Memory Abstraction


### PR DESCRIPTION
I believe the absence of this import in this module is what caused the prover to slow down when I made my changes to EVM. K-REFLECTION was no longer getting pulled in, which meant that the lemmas with #isConcrete were no longer being applied, slowing down the proofs.