### PR TITLE
Add owner with threshold

### DIFF
--- a/gnosis-imap/Makefile
+++ b/gnosis-imap/Makefile
@@ -12,7 +12,7 @@ KPROVE_OPTS:=--smt-prelude $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)
 SPEC_NAMES:=encodeTransactionData-1 \
             encodeTransactionData-2 \
             signatureSplit-proof \
-			addOwnerWithThreshold-success-1
+            addOwnerWithThreshold-success-1
 
 
 include ../resources/kprove.mak

--- a/gnosis-imap/Makefile
+++ b/gnosis-imap/Makefile
@@ -12,5 +12,7 @@ KPROVE_OPTS:=--smt-prelude $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)
 SPEC_NAMES:=encodeTransactionData-1 \
             encodeTransactionData-2 \
             signatureSplit-proof \
+			addOwnerWithThreshold-success-1
+
 
 include ../resources/kprove.mak

--- a/gnosis-imap/gnosis-imap-spec.ini
+++ b/gnosis-imap/gnosis-imap-spec.ini
@@ -148,6 +148,138 @@ proxy_storage:
 +requires:
     andBool 0 <Int DATA_LEN
 
+;[addOwnerWithThreshold]
+;output: _ => _
+;callData: #abiCallData("addOwnerWithThreshold", (#address(OWNER), #uint256(NEW_THRESHOLD)))
+;callValue: 0
+;this: PROXY_ID
+;proxy_storage:
+;    M1:IMap => M2:IMap
+;msg_sender: MSG_SENDER
+;+requires:
+;   andBool #rangeAddress(MSG_SENDER)
+;   andBool #rangeAddress(PROXY_ID)
+;   andBool #rangeAddress(OWNER)
+;   andBool #rangeUInt(256, NEW_THRESHOLD)
+;   andBool select(M1, #hashedLocation({COMPILER}, {THRESHOLD},  .IntList)) ==Int THRESHOLD
+;   andBool select(M1, #hashedLocation({COMPILER}, {OWNERCOUNT}, .IntList)) ==Int OWNERCOUNT 
+;   andBool select(M1, #hashedLocation({COMPILER}, {OWNERS},     1))        ==Int OLD_OWNER
+;   andBool #rangeUInt(256, THRESHOLD) 
+;   andBool #rangeUInt(256, OWNERCOUNT)
+;   andBool #rangeAddress(OLD_OWNER)
+;
+;[addOwnerWithThreshold-success]
+;statusCode: _ => EVMC_SUCCESS
+;log: _:List ( .List => ListItem(#abiEventLog(MSG_SENDER, "AddedOwner", #address(OWNER))) )
+;+requires:
+;   andBool select(M1, #hashedLocation({COMPILER}, {OWNERS}, OWNER)) ==Int 0
+;   andBool OWNER    =/=Int 0
+;   andBool OWNER    =/=Int 1
+;   andBool PROXY_ID ==Int MSG_SENDER
+;   andBool #rangeUInt(256, OWNERCOUNT +Int 1) 
+;
+;
+;[addOwnerWithThreshold-success-1]
+;+requires:
+;   andBool NEW_THRESHOLD ==Int THRESHOLD
+;ensures:
+;   ; ensures M2 ==IMap store(store(store(store(M1, #hashedLocation({COMPILER}, {OWNERS}, 1), OWNER), #hashedLocation({COMPILER}, {OWNERS}, OWNER), OLD_OWNER), #hashedLocation({COMPILER}, {THRESHOLD}, .IntList), THRESHOLD), #hashedLocation({COMPILER}, {OWNERCOUNT}, .IntList), OWNERCOUNT +Int 1)  
+;
+;[addOwnerWithThreshold-success-2]
+;callStack: _ => #abiCallData("changeThreshold", (#uint256(NEW_THRESHOLD)))
+;+requires:
+;   andBool NEW_THRESHOLD =/=Int THRESHOLD
+;ensures:
+;  ; ensures M2 ==IMap store(store(store(store(M1, #hashedLocation({COMPILER}, {OWNERS}, 1), OWNER), #hashedLocation({COMPILER}, {OWNERS}, OWNER), OLD_OWNER), #hashedLocation({COMPILER}, {THRESHOLD}, .IntList), _), #hashedLocation({COMPILER}, {OWNERCOUNT}, .IntList), OWNERCOUNT +Int 1)  
+;
+;[addOwnerWithThreshold-failure-1]
+;statusCode: _ => EVMC_REVERT
+;log: _
+;+requires:
+;    andBool ( PROXY_ID =/=Int MSG_SENDER 
+;      orBool  OWNER    ==Int 0
+;      orBool  OWNER    ==Int 1 
+;      orBool  select(M1, #hashedLocation({COMPILER}, {OWNERS}, OWNER)) =/=Int 0 )
+;ensures:
+;
+;[addOwnerWithThreshold-failure-2]
+;statusCode: _ => EVMC_INVALID_INSTRUCTION
+;log: _
+;+requires:
+;    andBool (OWNERCOUNT +Int 1) >=Int (2 ^Int 256)
+;    andBool OWNER =/=Int 0
+;    andBool OWNER =/=Int 1
+;ensures:
+
+[addOwnerWithThreshold]
+k: (#execute => #halt) ~> _
+callStack: _
+wordStack: .WordStack => _
+localMem: .IMap => _
+pc: 0 => _
+gas: #gas(STARTGAS, 0, 0) => _
+memoryUsed: 0 => _
+log: _ => _
+refund: _ => _
+coinbase: _ => _
+output: _ => _
+this: #PROXY_ID
+msg_sender: #PROXY_ID
+callData: #abiCallData("addOwnerWithThreshold", (
+            #address(OWNER), 
+            #uint256(NEW_THRESHOLD) ))
+callValue: 0
+proxy_storage:
+    M1:IMap => M2:IMap
++requires:
+    ;  address public constant SENTINEL_OWNERS = address(0x1);
+    andBool SENTINEL ==Int 1
+    ; Storage
+    andBool select(M1, #hashedLocation({COMPILER}, {OWNERS},     SENTINEL)) ==Int OLD_OWNER 
+    andBool select(M1, #hashedLocation({COMPILER}, {THRESHOLD},  .IntList)) ==Int THRESHOLD 
+    andBool select(M1, #hashedLocation({COMPILER}, {OWNERCOUNT}, .IntList)) ==Int OWNERCOUNT 
+    ; andBool M1 ==IMap store(store(store(_:IMap, #hashedLocation({COMPILER}, {OWNERS}, SENTINEL), INIT_SENTINEL), #hashedLocation({COMPILER}, {THRESHOLD}, .IntList), THRESHOLD), #hashedLocation({COMPILER}, {OWNERCOUNT}, .IntList), OWNERCOUNT)
+    ;; Range
+    andBool #rangeAddress(  OWNER)
+    andBool #rangeAddress(  SENTINEL)
+    andBool #rangeAddress(  INIT_SENTINEL)
+    andBool #rangeAddress(  INIT_OWNER)
+    andBool #rangeUInt(256, NEW_THRESHOLD)
+    andBool #rangeUInt(256, THRESHOLD)   
+    andBool #rangeUInt(256, OWNERCOUNT)
+    ; requirements from code
+    andBool INIT_OWNER ==Int 0
+
+[addOwnerWithThreshold-success]
+statusCode: _ => EVMC_SUCCESS
+log: _:List ( .List => ListItem(#abiEventLog(#PROXY_ID, "AddedOwner", #address(OWNER))) )
++requires:
+    andBool select(M1, #hashedLocation({COMPILER}, {OWNERS}, OWNER)) ==Int INIT_OWNER 
+    andBool #hashedLocation({COMPILER}, {OWNERS}, OWNER) =/=Int #hashedLocation({COMPILER}, {OWNERS}, SENTINEL)
+    andBool #hashedLocation({COMPILER}, {OWNERS}, OLD_OWNER) =/=Int #hashedLocation({COMPILER}, {OWNERS}, OWNER)
+    andBool #hashedLocation({COMPILER}, {OWNERS}, SENTINEL) =/=Int #hashedLocation({COMPILER}, {OWNERS}, OLD_OWNER)
+    andBool OWNER     =/=Int 0
+    andBool OWNER     =/=Int SENTINEL
+    andBool OWNER     =/=Int OLD_OWNER
+    andBool OLD_OWNER =/=Int SNEENTINEL
+    andBool #rangeUInt(256, OWNERCOUNT +Int 1)
+
+[addOwnerWithThreshold-success-1]
++requires:
+    andBool THRESHOLD ==Int NEW_THRESHOLD
+ensures:
+    ensures true
+    ; andBool select(M2, #hashedLocation({COMPILER}, {OWNERS}, SENTINEL))     ==Int OWNER
+    ; andBool select(M2, #hashedLocation({COMPILER}, {OWNERS}, OWNER))        ==Int OLD_OWNER
+    andBool select(M2, #hashedLocation({COMPILER}, {THRESHOLD}, .IntList))  ==Int THRESHOLD
+    andBool select(M2, #hashedLocation({COMPILER}, {OWNERCOUNT}, .IntList)) ==Int OWNERCOUNT +Int 1
+    ; andBool M1 ==IMap M2 except (
+;        SetItem(select(M2, #hashedLocation({COMPILER}, {OWNERS}, SENTINEL)))
+;        SetItem(select(M2, #hashedLocation({COMPILER}, {OWNERS}, OWNER)))
+;        SetItem(select(M2, #hashedLocation({COMPILER}, {OWNERCOUNT}, .IntList)))
+;        .Set
+;        )
+;
 [pgm]
 compiler: "Solidity"
 ; address masterCopy


### PR DESCRIPTION
I did the following:
  1. I added a (commented) sketch of the whole function
  2. I managed to prove the first success case with postconditions regarding `ownercount` and `threshold`. The storage contains the functions `chop()` and `&Int()`, I need to see where these come from and find a way to solve this in order to prove the spec with the rest of the postconditions.