### PR TITLE
fix #memoryUsageUpdate lemma

### DIFF
--- a/gnosis-imap/gnosis-imap-spec.ini
+++ b/gnosis-imap/gnosis-imap-spec.ini
@@ -506,7 +506,7 @@ pc: 19729 => 20110
     // Practical bound to help memory reasoning
     andBool #range(96 <= NEXT_LOC < 2 ^Int 32)
 
-    andBool FINAL_MEM_USAGE ==K #memoryUsageUpdate(MU, NEXT_LOC, 132)
+    andBool FINAL_MEM_USAGE ==K #memoryUsageUpdate(MU, NEXT_LOC +Int 100, 32)
 
 [handlePayment-send-failure-origin]
 gas: #gas(INITGAS, NONMEMGAS, MEMGAS) => #gas(INITGAS, NONMEMGAS +Int #callGas(BYZANTIUM, 0, #ORIGIN_ID, TOTAL_AMOUNT, false) +Int 714, MEMGAS +Int (Cmem(BYZANTIUM, FINAL_MEM_USAGE) -Int Cmem(BYZANTIUM, MU)))

--- a/gnosis/verification.k
+++ b/gnosis/verification.k
@@ -11,12 +11,12 @@ module VERIFICATION
   // ########################
 
     rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START0, WIDTH0)
-      requires START1 +Int WIDTH1 <Int START0 +Int WIDTH0
+      requires START1 +Int WIDTH1 <=Int START0 +Int WIDTH0
         andBool 0 <Int WIDTH0
         andBool 0 <=Int WIDTH1
 
     rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START1, WIDTH1)
-      requires START0 +Int WIDTH0 <=Int START1 +Int WIDTH1
+      requires START0 +Int WIDTH0 <Int START1 +Int WIDTH1
         andBool 0 <=Int WIDTH0
         andBool 0 <Int WIDTH1
 


### PR DESCRIPTION
outer #memoryUsageUpdate can replace the inner one when it's strictly large