### PR TITLE
Solving parsing errors in specs

### DIFF
--- a/gnosis/gnosis-spec.ini
+++ b/gnosis/gnosis-spec.ini
@@ -6,7 +6,6 @@ callStack: _
 wordStack: .WordStack => _
 localMem: .Map => _
 pc: 0 => _
-gas: #infinity => _
 memoryUsed: 0 => _
 callDepth: CD
 log: _ => _
@@ -14,21 +13,44 @@ refund: _ => _
 coinbase: _ => _
 ; account 1 has to be active, otherwise there will be branching on <k>: #accountNonexistent(1)
 activeAccounts: SetItem(MASTER_COPY_ID) SetItem(PROXY_ID) SetItem(ORIGIN_ID) SetItem(1) _:Set
-master_copy_bal: _
-master_copy_storage: _:Map
+; master_copy
+master_copy_bal: MASTER_BAL
+master_copy_storage: _
+master_copy_origstorage: _
 master_copy_nonce: _
-proxy_bal: 1000000000
+; proxy
+proxy_bal: PROXY_BAL
+proxy_storage: _
+proxy_origstorage: _
 proxy_nonce: _
-origin_bal: _
-origin_code: ""
-origin_storage: _:Map
+; origin
+origin_bal: ORIGIN_BAL
+origin_code: _
+origin_storage: _
+origin_origstorage: _
 origin_nonce: _
+; acct_to
+acct_to_bal: ACCT_TO_BAL
+acct_to_code: _
+acct_to_storage: _
+acct_to_origstorage: _
+acct_to_nonce: _
+; refund_receiver
+receiver_bal: RECEIVER_BAL
+receiver_code: _
+receiver_storage: _
+receiver_origstorage: _
+receiver_nonce: _
 accounts:
 requires:
     andBool #range(0 <= CD < 1024)
+    andBool #rangeUInt(256, MASTER_BAL)
+    andBool #rangeUInt(256, PROXY_BAL)
+    andBool #rangeUInt(256, ORIGIN_BAL)
+    andBool #rangeUInt(256, ACCT_TO_BAL)
+    andBool #rangeUInt(256, RECEIVER_BAL)
 ensures:
 attribute:
-
 
 [encodeTransactionData]
 ; output = bytes32(32) bytes32(66) bytes1(0x19) bytes1(0x1) bytes32(DOMAIN_SEPARATOR) bytes32(SAFE_TX_HASH) bytes30(0)
@@ -54,6 +76,7 @@ callData: #abiCallData("encodeTransactionData", (
             #address(REFUND_RECEIVER),
             #uint256(NONCE) ))
 callValue: 0
+gas: #gas(STARTGAS, 0, 0) => _
 proxy_storage:
     store(store(M, #hashedLocation({COMPILER}, {MASTER_COPY}, .IntList), MASTER_COPY_ID),
                    #hashedLocation({COMPILER}, {DOMAIN_SEPARATOR}, .IntList), DOMAIN_SEPARATOR)
@@ -99,6 +122,7 @@ this: #PROXY_ID
 msg_sender: MSG_SENDER
 callData: #abiCallData("signatureSplit", #bytes(#buf(65 *Int NR_SIG, SIG_BYTES)), #uint256(POS))
 callValue: 0
+gas: #gas(STARTGAS, 0, 0) => _
 proxy_storage:
     _:Map
 +requires:
@@ -128,6 +152,7 @@ callData: #abiCallData("checkSignatures", (
             #bytes(#buf(65 *Int NR_SIG, SIG_BYTES)),
             #bool(CONSUME_HASH) ))
 callValue: 0
+gas: #gas(STARTGAS, 0, 0) => _
 proxy_storage:
     store(store(M, #hashedLocation({COMPILER}, {MASTER_COPY}, .IntList), MASTER_COPY_ID),
                    #hashedLocation({COMPILER}, {THRESHOLD}, .IntList), THRESHOLD)


### PR DESCRIPTION
Solve parsing errors for the specs generated from `gnosis-spec.ini` from project `gnosis`.