### PR TITLE
License under The Reproducibility License 1.1.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,65 @@
+# Reproducibility License 1.1.0
+
+## Acceptance
+
+In order to get any license under these terms, you must
+agree to their rules.  Those rules are both obligations
+under your agreement and conditions to all your licenses.
+
+## <a id="reproducibility">Reproducibility</a>
+
+These terms license you _only_ for the following purposes:
+
+1.  You may reproduce published research results that the
+    licensor achieved using this software.
+
+2.  You may produce and reproduce research results of your
+    own, and of others, only for noncommercial purposes.
+
+These terms do _not_ license you for any other purpose,
+such as producing or reproducing new research results for
+commercial purposes.
+
+## Copyright
+
+The licensor grants you a copyright license for
+the software.  That license covers everything you
+might do with the software that would infringe the
+licensor's copyright in it, for the purposes permitted
+in [Reproducibility](#reproducibility).  That license
+does _not_ cover making changes or new work based on the
+software or removing this license from the software.
+
+## Patent
+
+The licensor grants you a patent license for the software.
+That license covers patent claims the licensor can
+license, or becomes able to license, that you would have to
+infringe to use the software for the purposes permitted in
+[Reproducibility](#reproducibility).  That license does
+_not_ cover selling the software.
+
+## Patent Defense
+
+If you or any affiliated company makes any written claim
+alleging that the software infringes or contributes to
+infringement of a patent, your patent license under these
+terms ends immediately.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer
+any licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not
+imply any other licenses.
+
+## Reliability
+
+The licensor may not revoke any license under these terms.
+
+## No Liability
+
+***As far as the law allows, this software comes as is,
+without any warranty or condition, and the licensor will
+not be liable to anyone for any damages related to this
+software or this license, under any kind of legal claim.***

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ We refer the reader to the following resources for background knowledge about th
 * [ERC20-EVM]: an EVM-level refinement of ERC20-K
 * [ERC777-K]: a formal specification of the high-level business logic of [ERC777]
 
+## License
+
+Copyrightable work in this repository is licensed by Runtime Verification, Inc. under the terms of [The Reproducibility License 1.1.0](/LICENSE.md), a restrictive license.  That license is very readable, and you should read it.  Most will want to pay special attention to its [Reproducibility section](./LICENSE.md#reproducibility).
+
+Other parts of the proof toolchain, including the K-framework, are licensed under different, open source terms, like those of The University of Illinois/NCSA Open Source License.
+
 ## Disclaimer
 
 This repository does not constitute legal or investment advice. The preparers of this repository present it as an informational exercise documenting the due diligence involved in the secure development of the target contract only, and make no material claims or guarantees concerning the contract's operation post-deployment. The preparers of this repository assume no liability for any and all potential consequences of the deployment or use of this contract.


### PR DESCRIPTION
cc @pmackay1982 and @daejunpark 

This pull request adds a public license to the repository, which it did not have before. It also adds a new section to README mentioning that licensing, linking directly to the most important section of its text, and noting that other parts of the tool chain are and remain open source, under their respective licenses.