### PR TITLE
kprove.mak: fix. We don't need git update option `--remote`. It makes K and submodules out of sync

### DIFF
--- a/resources/kprove.mak
+++ b/resources/kprove.mak
@@ -129,7 +129,7 @@ $(K_REPO_DIR)/mvn.timestamp: $(K_VERSION_FILE) | $(K_REPO_DIR)
 	cd $(K_REPO_DIR) \
 		&& git fetch \
 		&& git reset --hard $(K_VERSION) \
-		&& git submodule update --init --recursive --remote \
+		&& git submodule update --init --recursive \
 		&& mvn package -DskipTests -Dllvm.backend.skip -Dhaskell.backend.skip
 	touch $@
 


### PR DESCRIPTION
I introduced option `git checkout --remote` at some point in the past but turns out it was wrong.