### PR TITLE
Removed `  imports ETHEREUM-SIMULATION` from everywhere. Not used anyway

### DIFF
--- a/bihu/module-tmpl.k
+++ b/bihu/module-tmpl.k
@@ -2,7 +2,6 @@ requires "abstract-semantics-direct-gas.k"
 requires "verification.k"
 
 module {MODULE}-SPEC
-  imports ETHEREUM-SIMULATION
   imports ABSTRACT-SEMANTICS-DIRECT-GAS
   imports VERIFICATION
 

--- a/casper/module-tmpl.k
+++ b/casper/module-tmpl.k
@@ -2,7 +2,6 @@ requires "abstract-semantics.k"
 requires "verification.k"
 
 module {MODULE}-SPEC
-  imports ETHEREUM-SIMULATION
   imports ABSTRACT-SEMANTICS
   imports VERIFICATION
 

--- a/deposit/bytecode-verification/module-tmpl.k
+++ b/deposit/bytecode-verification/module-tmpl.k
@@ -3,7 +3,6 @@ requires "verification.k"
 
 module {MODULE}-SPEC
 
-imports ETHEREUM-SIMULATION
 imports ABSTRACT-SEMANTICS
 imports VERIFICATION
 

--- a/erc20/module-tmpl.k
+++ b/erc20/module-tmpl.k
@@ -2,7 +2,6 @@ requires "abstract-semantics-segmented-gas.k"
 requires "verification.k"
 
 module {MODULE}-SPEC
-  imports ETHEREUM-SIMULATION
   imports ABSTRACT-SEMANTICS-SEGMENTED-GAS
   imports VERIFICATION
 

--- a/gnosis/module-tmpl.k
+++ b/gnosis/module-tmpl.k
@@ -2,7 +2,6 @@ requires "abstract-semantics.k"
 requires "verification.k"
 
 module {MODULE}-SPEC
-  imports ETHEREUM-SIMULATION
   imports ABSTRACT-SEMANTICS
   imports VERIFICATION
 

--- a/proxied-token/module-tmpl.k
+++ b/proxied-token/module-tmpl.k
@@ -2,7 +2,6 @@ requires "abstract-semantics-direct-gas.k"
 requires "verification.k"
 
 module {MODULE}-SPEC
-  imports ETHEREUM-SIMULATION
   imports ABSTRACT-SEMANTICS-DIRECT-GAS
   imports VERIFICATION
 

--- a/resources/balanceOf-spec.k
+++ b/resources/balanceOf-spec.k
@@ -2,7 +2,6 @@ requires "abstract-semantics.k"
 requires "verification.k"
 
 module BALANCEOF-SPEC
-  imports ETHEREUM-SIMULATION
   imports ABSTRACT-SEMANTICS
   imports VERIFICATION
 

--- a/resources/sum-to-n.md
+++ b/resources/sum-to-n.md
@@ -45,7 +45,6 @@ One challenge in verifying this program is to identify the conditions under whic
 
 ```{.k .sum-to-n}
 module SUM-TO-N-SPEC
-    imports ETHEREUM-SIMULATION
     imports VERIFICATION
 ```
 

--- a/uniswap/module-tmpl.k
+++ b/uniswap/module-tmpl.k
@@ -2,7 +2,6 @@ requires "abstract-semantics.k"
 requires "verification.k"
 
 module {MODULE}-SPEC
-  imports ETHEREUM-SIMULATION
   imports ABSTRACT-SEMANTICS
   imports VERIFICATION
 


### PR DESCRIPTION
Required for Haskell.