### PR TITLE
Deposit lemmas

### DIFF
--- a/deposit/bytecode-verification/lemmas.k
+++ b/deposit/bytecode-verification/lemmas.k
@@ -83,12 +83,6 @@ module LEMMAS
     rule 0 <=Int #asWord(WS)             => true
     rule         #asWord(WS) <Int pow256 => true
 
-    rule 0 <=Int hash1(_)             => true
-    rule         hash1(_) <Int pow256 => true
-
-    rule 0 <=Int hash2(_,_)             => true
-    rule         hash2(_,_) <Int pow256 => true
-
     rule 0 <=Int chop(V)             => true
     rule         chop(V) <Int pow256 => true
 
@@ -565,41 +559,6 @@ module LEMMAS
     //////////////////////////
     // Hash Abstraction
     //////////////////////////
-
-    // TODO: drop hash1 and keccakIntList once new vyper hashed location scheme is captured in edsl.md
-
-    syntax Int ::= hash1(Int)      [function, smtlib(smt_hash1)]
-                 | hash2(Int, Int) [function, smtlib(smt_hash2)]
-
-    rule hash1(V) => keccak(#padToWidth(32, #asByteStack(V)))
-      requires 0 <=Int V andBool V <Int pow256
-      [concrete]
-
-    rule hash2(V1, V2) => keccak(   #padToWidth(32, #asByteStack(V1))
-                                 ++ #padToWidth(32, #asByteStack(V2)))
-      requires 0 <=Int V1 andBool V1 <Int pow256
-       andBool 0 <=Int V2 andBool V2 <Int pow256
-      [concrete]
-
-    rule keccakIntList(V:Int .IntList) => hash1(V)
-    rule keccakIntList(V1:Int V2:Int .IntList) => hash2(V1, V2)
-
-    // for terms came from bytecode not via #hashedLocation
-    rule keccak(WS) => keccakIntList(byteStack2IntList(WS))
-      requires ( notBool #isConcrete(WS) )
-       andBool ( #sizeWordStack(WS) ==Int 32 orBool #sizeWordStack(WS) ==Int 64 )
-
-    // select/store key equality
-
-    rule hash2(A,B) ==K I => false
-      requires #isConcrete(I)
-       andBool I <Int 20 //random small-ish number bigger than any fixed storage location
-
-    rule I ==K hash2(A,B) => hash2(A,B) ==K I
-      requires #isConcrete(I)
-
-    rule hash2(A1,B1) ==K hash2(A2,B2) => A1 ==Int A2 andBool B1 ==Int B2
-
     // sha256
 
     syntax Int ::= #sha256 ( WordStack ) [function, smtlib(sha256)]

--- a/deposit/bytecode-verification/lemmas.k
+++ b/deposit/bytecode-verification/lemmas.k
@@ -73,8 +73,8 @@ module LEMMAS
     rule         #bufElm(_, _) <Int pow256 => true
 
     // X xorInt (pow256 - 1)
-    rule 0 <=Int X xorInt 115792089237316195423570985008687907853269984665640564039457584007913129639935             => true  requires 0<=Int X andBool X <Int pow256
-    rule         X xorInt 115792089237316195423570985008687907853269984665640564039457584007913129639935 <Int pow256 => true  requires 0<=Int X andBool X <Int pow256
+    rule 0 <=Int X xorInt maxUInt256             => true  requires 0<=Int X andBool X <Int pow256
+    rule         X xorInt maxUInt256 <Int pow256 => true  requires 0<=Int X andBool X <Int pow256
 
     rule 0 <=Int nthbyteof(V, I, N)             => true
     rule         nthbyteof(V, I, N) <Int 256    => true
@@ -176,21 +176,21 @@ module LEMMAS
     rule N &Int MASK => N  requires MASK ==Int (2 ^Int (log2Int(MASK) +Int 1)) -Int 1 // MASK = 0xffff...f
                             andBool 0 <=Int N andBool N <=Int MASK
 
-    // 0xff..ff00..00 (16 1's followed by 240 0's)
-    rule 115790322390251417039241401711187164934754157181743688420499462401711837020160 &Int #asWord(WS1 ++ WS2)
+    // 0xff00..00 (16 1's followed by 240 0's)
+    rule (pow256 -Int (2 ^Int 240)) &Int #asWord(WS1 ++ WS2)
         => #asWord(WS1 ++ #buf(30, 0))
       requires #sizeWordStack(WS1) ==Int 2
        andBool #sizeWordStack(WS2) ==Int 30
 
     // x &Int (NOT 31)
-    rule X &Int 115792089237316195423570985008687907853269984665640564039457584007913129639904 => (X /Int 32) *Int 32  requires 0 <=Int X
+    rule X &Int (pow256 -Int 32) => (X /Int 32) *Int 32  requires 0 <=Int X
 
     // 2^256 - 2^160 = 0xff..ff00..00 (96 1's followed by 160 0's)
-    rule 115792089237316195423570985007226406215939081747436879206741300988257197096960 &Int ADDR => 0
+    rule (pow256 -Int pow160) &Int ADDR => 0
       requires #rangeAddress(ADDR)
 
     // #asWord(WS) &Int (pow256 - 1)
-    rule #asWord(WS) &Int 115792089237316195423570985008687907853269984665640564039457584007913129639935 => #asWord(WS)
+    rule #asWord(WS) &Int maxUInt256 => #asWord(WS)
 
     //
     // boolean

--- a/deposit/bytecode-verification/lemmas.k
+++ b/deposit/bytecode-verification/lemmas.k
@@ -398,11 +398,6 @@ module LEMMAS
 
     rule nthbyteof(N, 0, 1) => N
 
-    syntax Bool ::= #isRegularWordStack ( WordStack ) [function]
- // -------------------------------------------------------
-    rule #isRegularWordStack(N : WS => WS)
-    rule #isRegularWordStack(.WordStack) => true
-
     // for Vyper
     rule #padToWidth(N, #asByteStack(#asWord(WS))) => WS
       requires #noOverflow(WS) andBool N ==Int #sizeWordStack(WS)


### PR DESCRIPTION
Reduces the trusted base of the deposit contract verification, mainly by removing lemmas that I think are not used by these specs anyway.