### PR TITLE
Deposit: Improve init spec

### DIFF
--- a/deposit/bytecode-verification/Makefile
+++ b/deposit/bytecode-verification/Makefile
@@ -12,10 +12,8 @@ KPROVE_OPTS:=--smt-prelude $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)
              --branching-allowed 0 \
              --z3-cnstr-timeout 100
 
-SPEC_NAMES:=init-init \
-            init-loop0 \
-            init-loop-enter \
-            init-loop-exit \
+SPEC_NAMES:=init-success \
+            init-revert \
             to_little_endian_64 \
             get_deposit_root-init \
             get_deposit_root-loop0-then \
@@ -47,7 +45,6 @@ SPEC_NAMES:=init-init \
             revert-invalid_function_identifier-lt_4 \
             revert-invalid_function_identifier-ge_4-lt_32 \
             revert-invalid_function_identifier-ge_4-ge_32 \
-            revert-init \
             revert-get_deposit_root \
             revert-get_deposit_count
 

--- a/deposit/bytecode-verification/Makefile
+++ b/deposit/bytecode-verification/Makefile
@@ -21,7 +21,8 @@ SPEC_NAMES:=init-success \
             get_deposit_root-loop-body-then \
             get_deposit_root-loop-body-else \
             get_deposit_root-loop-exit \
-            get_deposit_count \
+            get_deposit_count-success \
+            get_deposit_count-revert \
             deposit-init \
             deposit-subcall_1 \
             deposit-subcall_2 \
@@ -45,21 +46,17 @@ SPEC_NAMES:=init-success \
             revert-invalid_function_identifier-lt_4 \
             revert-invalid_function_identifier-ge_4-lt_32 \
             revert-invalid_function_identifier-ge_4-ge_32 \
-            revert-get_deposit_root \
-            revert-get_deposit_count
+            revert-get_deposit_root
 
 include ../../resources/kprove.mak
 
 # non-standard spec generation
 
-$(SPECS_DIR)/$(SPEC_GROUP)/get_deposit_root-loop-exit-spec.k: $(TMPLS) $(SPEC_INI)
+$(SPECS_DIR)/$(SPEC_GROUP)/get_deposit_root-loop-exit-spec.k: $(TMPLS) $(SPEC_INI) $(LEMMAS)
 	python3 $(RESOURCES)/gen-spec.py $(TMPLS) $(SPEC_INI) get_deposit_root-loop-exit to_little_endian_64-trusted get_deposit_root-loop-exit > $@
 
-$(SPECS_DIR)/$(SPEC_GROUP)/get_deposit_count-spec.k: $(TMPLS) $(SPEC_INI)
-	python3 $(RESOURCES)/gen-spec.py $(TMPLS) $(SPEC_INI) get_deposit_count            to_little_endian_64-trusted get_deposit_count            > $@
-
-$(SPECS_DIR)/$(SPEC_GROUP)/deposit-subcall_1-spec.k: $(TMPLS) $(SPEC_INI)
+$(SPECS_DIR)/$(SPEC_GROUP)/deposit-subcall_1-spec.k: $(TMPLS) $(SPEC_INI) $(LEMMAS)
 	python3 $(RESOURCES)/gen-spec.py $(TMPLS) $(SPEC_INI) deposit-subcall_1            to_little_endian_64-trusted deposit-subcall_1            > $@
 
-$(SPECS_DIR)/$(SPEC_GROUP)/deposit-subcall_2-spec.k: $(TMPLS) $(SPEC_INI)
+$(SPECS_DIR)/$(SPEC_GROUP)/deposit-subcall_2-spec.k: $(TMPLS) $(SPEC_INI) $(LEMMAS)
 	python3 $(RESOURCES)/gen-spec.py $(TMPLS) $(SPEC_INI) deposit-subcall_2            to_little_endian_64-trusted deposit-subcall_2            > $@

--- a/deposit/bytecode-verification/deposit-spec-full.ini
+++ b/deposit/bytecode-verification/deposit-spec-full.ini
@@ -1,0 +1,1420 @@
+; contract: https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/deposit_contract/contracts/validator_registration.vy
+; vyper: https://github.com/vyperlang/vyper/tree/1761-HOTFIX-v0.1.0-beta.13
+
+[root]
+k: #execute
+; default
+pc: 0 => _
+word_stack: .WordStack => _
+local_mem: .Map => _
+gas: #symGas(G, 0, 0, .List, Cmem({SCHEDULE}, #symMem(0, .Set))) => _
+memory_used: #symMem(0, .Set) => _
+; no changes
+call_data: _
+log: _
+refund: _
+storage: _
+orig_storage: _
+balance: INIT_BALANCE
+nonce: INIT_NONCE
+code: {RUNTIME_CODE}
+; ignore (potential) changes
+output: _ => _
+status_code: _ => _
+; variables
+comment:
+schedule:       ISTANBUL
+call_stack:     CALL_STACK
+this:           THIS
+msg_sender:     MSG_SENDER
+call_value:     CALL_VALUE
+call_depth:     CALL_DEPTH
+coinbase:       COIN_BASE
+active_accounts:
+accounts:
+requires:
+    // conditions
+    andBool #range(0 <= CALL_DEPTH < 1024)
+    andBool #regularAddress({SCHEDULE}, THIS)
+    // types
+    andBool #rangeAddress(THIS)
+    andBool #rangeAddress(MSG_SENDER)
+    andBool #rangeUInt(256, CALL_VALUE)
+;   andBool #rangeUInt(256, INIT_GAS)
+    andBool #rangeUInt(256, INIT_BALANCE)
+    andBool #rangeUInt(256, INIT_NONCE)
+    andBool #rangeUInt(256, EXTRA_CALL_DATA_SIZE)
+    andBool isInitGas(G)
+ensures:
+attribute:
+VYPER_GENERATED_BOUNDS:
+    ; bounds - vyper generated
+    [  32 := #buf(32, 1461501637330902918203684832716283019655932542976) ]
+    [  64 := #buf(32, 170141183460469231731687303715884105727) ]
+    [  96 := #buf(32, 115792089237316195423570985008687907853099843482180094807725896704197245534208) ]
+    [ 128 := #buf(32, 1701411834604692317316873037158841057270000000000) ]
+    [ 160 := #buf(32, 115792089237316195423570985006986496018665292348323691002298742950633129639936) ]
+LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT:
+    [ 352 /* = 320 + 32 *  1      */ := #buf(32, {RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64}) ]  /* return address */
+    [ 320 /* = 320 + 32 *  0      */ := #buf(32, DEPOSIT_COUNT) ]  /* argument */
+    [ 384 /* = 320 + 32 *  2      */ := #buf(32, Y8) ]             /* y: uint256 = (y << 8) + bitwise_and(x, 255) */
+    [ 416 /* = 320 + 32 *  3      */ := #buf(32, X8) ]             /* x: uint256 = (x >> 8) */
+    [ 448 /* = 320 + 32 *  4      */ := #buf(32, 8) ]              /* for-loop index */
+    [ 480 /* = 320 + 32 *  5      */ := #buf(32, X7 &Int 255) ]    /* bitwise_and(x, 255) */
+    [ 544 /* = 320 + 32 *  7      */ := #buf(32, Y8) ]             /* memcpy(544 <- 384, 32) */
+    [ 536 /* = 320 + 32 *  6 + 24 */ := #buf(32, 8) ]              /* for slice(convert(y, bytes32), start=24, len=8) */
+    [ 704 /* = 320 + 32 * 12      */ := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ]  /* return: bytes[8] */ /* memcpy(704 <- 536, 40) */
+    {TO_LITTLE_ENDIAN_64_ZERO_PADDING}
+LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT:
+    [ 352 /* = 320 + 32 *  1      */ := #buf(32, {RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT}) ]  /* return address */
+    [ 320 /* = 320 + 32 *  0      */ := #buf(32, {DEPOSIT_AMOUNT}) ]   /* argument */
+    [ 384 /* = 320 + 32 *  2      */ := #buf(32, YY8) ]                /* y: uint256 = (y << 8) + bitwise_and(x, 255) */
+    [ 416 /* = 320 + 32 *  3      */ := #buf(32, XX8) ]                /* x: uint256 = (x >> 8) */
+    [ 448 /* = 320 + 32 *  4      */ := #buf(32, 8) ]                  /* for-loop index */
+    [ 480 /* = 320 + 32 *  5      */ := #buf(32, XX7 &Int 255) ]       /* bitwise_and(x, 255) */
+    [ 544 /* = 320 + 32 *  7      */ := #buf(32, YY8) ]                /* memcpy(544 <- 384, 32) */
+    [ 536 /* = 320 + 32 *  6 + 24 */ := #buf(32, 8) ]                  /* for slice(convert(y, bytes32), start=24, len=8) */
+    [ 704 /* = 320 + 32 * 12      */ := #buf(32, 8) ++ #bufSeg(#buf(32, YY8), 24, 8) ]  /* return: bytes[8] */ /* memcpy(704 <- 536, 40) */
+    {TO_LITTLE_ENDIAN_64_ZERO_PADDING}
+TO_LITTLE_ENDIAN_64_ZERO_PADDING:
+    [ 800 /* = 320 + 32 * 15      */ := #buf(32, 32) ]             /* padding loop index */
+    [ 744 /* = 320 + 32 * 13 +  8 */ <- 0 ]                        /* padding */
+    [ 745 /* = 320 + 32 * 13 +  9 */ <- 0 ]
+    [ 746 /* = 320 + 32 * 13 + 10 */ <- 0 ]
+    [ 747 /* = 320 + 32 * 13 + 11 */ <- 0 ]
+    [ 748 /* = 320 + 32 * 13 + 12 */ <- 0 ]
+    [ 749 /* = 320 + 32 * 13 + 13 */ <- 0 ]
+    [ 750 /* = 320 + 32 * 13 + 14 */ <- 0 ]
+    [ 751 /* = 320 + 32 * 13 + 15 */ <- 0 ]
+    [ 752 /* = 320 + 32 * 13 + 16 */ <- 0 ]
+    [ 753 /* = 320 + 32 * 13 + 17 */ <- 0 ]
+    [ 754 /* = 320 + 32 * 13 + 18 */ <- 0 ]
+    [ 755 /* = 320 + 32 * 13 + 19 */ <- 0 ]
+    [ 756 /* = 320 + 32 * 13 + 20 */ <- 0 ]
+    [ 757 /* = 320 + 32 * 13 + 21 */ <- 0 ]
+    [ 758 /* = 320 + 32 * 13 + 22 */ <- 0 ]
+    [ 759 /* = 320 + 32 * 13 + 23 */ <- 0 ]
+    [ 760 /* = 320 + 32 * 13 + 24 */ <- 0 ]
+    [ 761 /* = 320 + 32 * 13 + 25 */ <- 0 ]
+    [ 762 /* = 320 + 32 * 13 + 26 */ <- 0 ]
+    [ 763 /* = 320 + 32 * 13 + 27 */ <- 0 ]
+    [ 764 /* = 320 + 32 * 13 + 28 */ <- 0 ]
+    [ 765 /* = 320 + 32 * 13 + 29 */ <- 0 ]
+    [ 766 /* = 320 + 32 * 13 + 30 */ <- 0 ]
+    [ 767 /* = 320 + 32 * 13 + 31 */ <- 0 ]
+    [ 672 /* = 320 + 32 * 11      */ := #buf(32, 32) ]             /* ??? */
+    [ 640 /* = 320 + 32 * 10      */ := #buf(32, 0) ]              /* ??? */
+LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT:
+    // let-bindings
+    andBool X1 ==Int DEPOSIT_COUNT /Int 256
+    andBool X2 ==Int X1            /Int 256
+    andBool X3 ==Int X2            /Int 256
+    andBool X4 ==Int X3            /Int 256
+    andBool X5 ==Int X4            /Int 256
+    andBool X6 ==Int X5            /Int 256
+    andBool X7 ==Int X6            /Int 256
+    andBool X8 ==Int X7            /Int 256
+    //
+    andBool Y1 ==Int          DEPOSIT_COUNT &Int 255
+    andBool Y2 ==Int (Y1 *Int 256) +Int (X1 &Int 255)
+    andBool Y3 ==Int (Y2 *Int 256) +Int (X2 &Int 255)
+    andBool Y4 ==Int (Y3 *Int 256) +Int (X3 &Int 255)
+    andBool Y5 ==Int (Y4 *Int 256) +Int (X4 &Int 255)
+    andBool Y6 ==Int (Y5 *Int 256) +Int (X5 &Int 255)
+    andBool Y7 ==Int (Y6 *Int 256) +Int (X6 &Int 255)
+    andBool Y8 ==Int (Y7 *Int 256) +Int (X7 &Int 255)
+LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT:
+    // let-bindings
+    andBool XX1 ==Int {DEPOSIT_AMOUNT} /Int 256
+    andBool XX2 ==Int XX1              /Int 256
+    andBool XX3 ==Int XX2              /Int 256
+    andBool XX4 ==Int XX3              /Int 256
+    andBool XX5 ==Int XX4              /Int 256
+    andBool XX6 ==Int XX5              /Int 256
+    andBool XX7 ==Int XX6              /Int 256
+    andBool XX8 ==Int XX7              /Int 256
+    //
+    andBool YY1 ==Int         {DEPOSIT_AMOUNT} &Int 255
+    andBool YY2 ==Int (YY1 *Int 256) +Int (XX1 &Int 255)
+    andBool YY3 ==Int (YY2 *Int 256) +Int (XX2 &Int 255)
+    andBool YY4 ==Int (YY3 *Int 256) +Int (XX3 &Int 255)
+    andBool YY5 ==Int (YY4 *Int 256) +Int (XX4 &Int 255)
+    andBool YY6 ==Int (YY5 *Int 256) +Int (XX5 &Int 255)
+    andBool YY7 ==Int (YY6 *Int 256) +Int (XX6 &Int 255)
+    andBool YY8 ==Int (YY7 *Int 256) +Int (XX7 &Int 255)
+
+;
+; __init__
+;
+
+; @public
+; def __init__():
+;     for i in range(DEPOSIT_CONTRACT_TREE_DEPTH - 1):
+;         self.zero_hashes[i + 1] = sha256(concat(self.zero_hashes[i], self.zero_hashes[i]))
+
+[init]
+; for create
+code: {INIT_CODE}
+call_data: .WordStack
+storage: .Map
+orig_storage: .Map
+; for constructor
+PC_LOOPENTER: 164
+PC_LOOPHEAD: 369
+PC_END: 4684
+WORD_STACK_INIT: 31 : 320 : .WordStack
+LOCAL_MEM_INIT: .Map
+    {VYPER_GENERATED_BOUNDS}
+    [ 320 := #buf(32, 0) ]              /* i = 0 */
+
+[init-init]
+pc: 0 => {PC_LOOPENTER}
+word_stack: .WordStack => {WORD_STACK_INIT}
+local_mem: .Map => {LOCAL_MEM_INIT}
++requires:
+    // conditions
+    andBool CALL_VALUE ==Int 0
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => 352, .Set)
+GAS_COST: 85
+
+[init-loop0]
+pc: {PC_LOOPENTER} => {PC_LOOPHEAD}
+word_stack: {WORD_STACK_INIT} => 1 : {WORD_STACK_INIT}
+local_mem: {LOCAL_MEM_INIT} => {LOCAL_MEM_INIT}
+    [ 192 /* scratchpad     */ := #buf(32, 2) ]                  /* zero_hashes storage index = 2 */
+    [ 384 /* = 320 + 32 * 2 */ := #buf(32, select(.Map, #hashedLocation({COMPILER}, {ZERO_HASHES}, 0))) ]    /* self.zero_hashes[0] */
+    [ 416 /* = 320 + 32 * 3 */ := #buf(32, select(.Map, #hashedLocation({COMPILER}, {ZERO_HASHES}, 0))) ]    /* self.zero_hashes[0] */
+    [ 352 /* = 320 + 32 * 1 */ := #buf(32, 64) ]                 /* size of sha256 */
+    [ 192 /* scratchpad     */ := #buf(32, {ZERO_HASHES_1}) ]    /* sha256(384, 64) return */
+    [ 192 /* scratchpad     */ := #buf(32, 2) ]                  /* zero_hashes storage index = 2 */
+    [ 320 /* = 320 + 32 * 0 */ := #buf(32, 1) ]                  /* i = 1 */
+storage: .Map => .Map
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 1) <- {ZERO_HASHES_1} ]
+refund: _ => _
+ZERO_HASHES_1: #sha256(#buf(32, 0) ++ #buf(32, 0))
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(352 => 448, .Set)
+GAS_COST: 21667
+
+[init-loop]
+LOCAL_MEM_LOOPHEAD: {LOCAL_MEM_INIT}
+    [ 192 /* scratchpad     */ := #buf(32, 2) ]              /* zero_hashes storage index = 2 */
+    [ 384 /* = 320 + 32 * 2 */ := #buf(32, ANON_1) ]         /* self.zero_hashes[i] */
+    [ 416 /* = 320 + 32 * 3 */ := #buf(32, ANON_2) ]         /* self.zero_hashes[i] */
+    [ 352 /* = 320 + 32 * 1 */ := #buf(32, 64) ]             /* size of sha256 */
+    [ 320 /* = 320 + 32 * 0 */ := #buf(32, I) ]              /* i = i + 1 */
+storage: M
++requires:
+    // conditions
+    andBool #range(0 <= I <= 31)
+    // types
+    andBool isStorage(M)
+    andBool #rangeUInt(256, ANON_1)
+    andBool #rangeUInt(256, ANON_2)
+
+[init-loop-enter]
+pc: {PC_LOOPHEAD}
+word_stack: (I => I +Int 1) : {WORD_STACK_INIT}
+local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
+    [ 192 /* scratchpad     */ := #buf(32, 2) ]                  /* zero_hashes storage index = 2 */
+    [ 384 /* = 320 + 32 * 2 */ := #buf(32, select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, I))) ]  /* self.zero_hashes[i] */
+    [ 416 /* = 320 + 32 * 3 */ := #buf(32, select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, I))) ]  /* self.zero_hashes[i] */
+    [ 352 /* = 320 + 32 * 1 */ := #buf(32, 64) ]                 /* size of sha256 */
+    [ 192 /* scratchpad     */ := #buf(32, {ZERO_HASHES_I+1}) ]  /* sha256(384, 64) return */
+    [ 192 /* scratchpad     */ := #buf(32, 2) ]                  /* zero_hashes storage index = 2 */
+    [ 320 /* = 320 + 32 * 0 */ := #buf(32, I +Int 1) ]           /* i = i + 1 */
+storage: M => M
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, I +Int 1) <- {ZERO_HASHES_I+1} ]
+refund: _ => _
+ZERO_HASHES_I: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, I))
+ZERO_HASHES_I+1: #sha256(#buf(32, {ZERO_HASHES_I}) ++ #buf(32, {ZERO_HASHES_I}))
++requires:
+    // conditions
+    andBool I <Int 31
+gas:         #symGas(G, 0 => 6689, 0 => 21689, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(448, .Set)
+
+[init-loop-exit]
+k: #execute => #halt
+status_code: _ => EVMC_SUCCESS
+pc: {PC_LOOPHEAD} => {PC_END}
+output: _ => #parseByteStack({RUNTIME_CODE})
+word_stack: I : {WORD_STACK_INIT} => .WordStack
+local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
+    [ 0 := #parseByteStack({RUNTIME_CODE}) ]
++requires:
+    // conditions
+    andBool I ==Int 31
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(448 => 4278, .Set)
+GAS_COST: 471
+
+;
+; to_little_endian_64
+;
+
+[to_little_endian_64-trusted]
+gas:         #symGas(G, LB => LB +Int {GAS_COST}, UB => UB +Int {GAS_COST}, GS, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(MU => maxInt(MU, {MEM_COST}), MUS)
+attribute: [trusted, matching(#symGas,#symMem,Cmem)]
+
+[to_little_endian_64]
+k: #execute
+pc: {PC_BEGIN} => {PC_END}
+word_stack: {WORD_STACK_BEGIN} => {WORD_STACK_END}
+local_mem: {LOCAL_MEM_BEGIN} => {LOCAL_MEM_END}
+LOOP_BOUND: 8
+SLICE_LENGTH: 8
+PC_BEGIN:  169
+PC_MIDDLE: 387
+PC_END:    636
+WORD_STACK_BEGIN:  RETURN_ADDR : VALUE                 : WS /* WS saves caller's local vars */
+WORD_STACK_MIDDLE: {LOOP_BOUND} : 448                  : WS
+WORD_STACK_END:    RETURN_ADDR : 32 : 8 : {RETURN_VAL} : WS
+; RETURN_VAL: selectRange({LOCAL_MEM_END}, 736, 32)
+RETURN_VAL: #asWord(#bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0))
+LOCAL_MEM_BEGIN:  MEM
+LOCAL_MEM_MIDDLE: {LOCAL_MEM_BEGIN}  {LOCAL_MEM_UPDATE_FROM_BEGIN_TO_MIDDLE}
+LOCAL_MEM_END:    {LOCAL_MEM_MIDDLE} {LOCAL_MEM_UPDATE_FROM_MIDDLE_TO_END}
+LOCAL_MEM_UPDATE_FROM_BEGIN_TO_MIDDLE:
+    [ 352 /* = 320 + 32 *  1      */ := #buf(32, RETURN_ADDR) ]
+    [ 320 /* = 320 + 32 *  0      */ := #buf(32, VALUE) ]
+    [ 384 /* = 320 + 32 *  2      */ := #buf(32, Y8) ]             /* y: uint256 = (y << 8) + bitwise_and(x, 255) */
+    [ 416 /* = 320 + 32 *  3      */ := #buf(32, X8) ]             /* x: uint256 = (x >> 8) */
+    [ 448 /* = 320 + 32 *  4      */ := #buf(32, {LOOP_BOUND}) ]   /* for-loop index */
+    [ 480 /* = 320 + 32 *  5      */ := #buf(32, X7 &Int 255) ]    /* bitwise_and(x, 255) */
+LOCAL_MEM_UPDATE_FROM_MIDDLE_TO_END:
+    [ 544 /* = 320 + 32 *  7      */ := #buf(32, Y8) ]             /* memcpy(544 <- 384, 32) */
+    [ 536 /* = 320 + 32 *  6 + 24 */ := #buf(32, {SLICE_LENGTH}) ] /* for slice(convert(y, bytes32), start=24, len=8) */
+    [ 704 /* = 320 + 32 * 12      */ := #buf(32, {SLICE_LENGTH}) ++ #bufSeg(#buf(32, Y8), 24, {SLICE_LENGTH}) ]    /* return: bytes[8] */ /* memcpy(704 <- 536, 40) */
+    {TO_LITTLE_ENDIAN_64_ZERO_PADDING}
++requires:
+    // conditions
+    andBool #range(0 <= #sizeWordStack(WS) <= 1000) // NOTE: rough bound
+    andBool #rangeUInt(256, RETURN_ADDR)
+    andBool #rangeUInt(256, VALUE)
+    // let-bindings
+    andBool X1 ==Int VALUE /Int 256
+    andBool X2 ==Int X1    /Int 256
+    andBool X3 ==Int X2    /Int 256
+    andBool X4 ==Int X3    /Int 256
+    andBool X5 ==Int X4    /Int 256
+    andBool X6 ==Int X5    /Int 256
+    andBool X7 ==Int X6    /Int 256
+    andBool X8 ==Int X7    /Int 256
+    //
+    andBool Y1 ==Int                  VALUE &Int 255
+    andBool Y2 ==Int (Y1 *Int 256) +Int (X1 &Int 255)
+    andBool Y3 ==Int (Y2 *Int 256) +Int (X2 &Int 255)
+    andBool Y4 ==Int (Y3 *Int 256) +Int (X3 &Int 255)
+    andBool Y5 ==Int (Y4 *Int 256) +Int (X4 &Int 255)
+    andBool Y6 ==Int (Y5 *Int 256) +Int (X5 &Int 255)
+    andBool Y7 ==Int (Y6 *Int 256) +Int (X6 &Int 255)
+    andBool Y8 ==Int (Y7 *Int 256) +Int (X7 &Int 255)
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MEM_COST}, .Set)
+GAS_COST: 7556
+MEM_COST: 832
+
+[to_little_endian_64-forloop]
+pc: {PC_BEGIN} => {PC_MIDDLE}
+word_stack: {WORD_STACK_BEGIN} => {WORD_STACK_MIDDLE}
+local_mem: {LOCAL_MEM_BEGIN} => {LOCAL_MEM_MIDDLE}
+;   ; save call stack args
+;   [ 352 := #buf(32, RETURN_ADDR) ]
+;   [ 320 := #buf(32, VALUE) ]
+;   ; init locals
+;   [ 384 := #buf(32, 0) ]                  /* y: uint256 = 0 */
+;   [ 416 := #buf(32, VALUE) ]              /* x: uint256 = value */
+;   [ 448 := #buf(32, 0) ]                  /* init for-loop index */
+;   ; loop body (pc: 189 <-> 372)
+;   [ 384 := #buf(32, 0) ]                  /* y = shift(y, 8) */ /* y << 8 */
+;   [ 480 := #buf(32, VALUE &Int 255) ]     /* bitwise_and(x, 255) */
+;   [ 384 := #buf(32, VALUE &Int 255) ]     /* y = y + bitwise_and(x, 255) */
+;   [ 416 := #buf(32, VALUE /Int 256) ]     /* x = shift(x, -8) */ /* x >> 8 */
+;   [ 448 := #buf(32, 1) ]                  /* increase for-loop index */
+;   ; ... repeat loop body ...
+gas: #symGas(G, 0, 0, .List, Cmem({SCHEDULE}, #symMem(0, .Set))) => _
+memory_used: #symMem(0, .Set) => _
+
+[to_little_endian_64-return]
+pc: {PC_MIDDLE} => {PC_END}
+word_stack: {WORD_STACK_MIDDLE} => {WORD_STACK_END}
+local_mem: {LOCAL_MEM_MIDDLE} => {LOCAL_MEM_END}
+;   [ 544 := #buf(32, Y8) ]                 /* memcpy 544 <- 384 */
+;   [ 536 := #buf(32, 8) ]                  /* slice by overwrite */
+;   [ 704 := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8)) ]         /* prepareing for return value*/
+;
+;   [ 800 := #buf(32, 8) ]
+;   [ 744 <- 0 ]
+;   [ 800 := #buf(32, 9) ]
+;   [ 745 <- 0 ]
+;   ...
+;   [ 767 <- 0 ]                            /* padding */
+;   [ 800 := #buf(32, 32) ]                 /* padding loop index */
+;
+;   [ 672 := #buf(32, 32) ]
+;   [ 640 := #buf(32, 96) ]
+;   [ 640 := #buf(32, 64) ]
+;   [ 640 := #buf(32, 32) ]
+;   [ 640 := #buf(32, 0) ]
+gas: #symGas(G, 0, 0, .List, Cmem({SCHEDULE}, #symMem(0, .Set))) => _
+memory_used: #symMem(0, .Set) => _
+
+;
+; get_deposit_root
+;
+
+[get_deposit_root]
+; The term `#buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)` models certain extra call-data added accidently or intentionally.
+; This ensures that the function works correctly even in such a case.
+call_data: #abiCallData("get_deposit_root", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)
+storage: M
++requires:
+    // conditions
+    andBool CALL_VALUE ==Int 0
+    // types
+    andBool #rangeUInt(256, DEPOSIT_COUNT)
+    andBool isStorage(M)
+    // let-bindings
+    andBool DEPOSIT_COUNT ==Int select(M, #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList))
+PC_LOOPENTER: 697
+PC_LOOPHEAD: 968
+PC_END: 1291
+WORD_STACK_INIT: 32 : 416 : .WordStack
+LOCAL_MEM_BEGIN: .Map
+    ; function hash
+    [  28 := 197 : 242 : 137 : 47 : #take(28, #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)) ]
+    {VYPER_GENERATED_BOUNDS}
+LOCAL_MEM_INIT: {LOCAL_MEM_BEGIN}
+    ; locals
+    [ 320 /* = 320 + 32 * 0 */ := #buf(32, 0) ]              /* zero_bytes32: bytes32 = 0x0 */
+    [ 352 /* = 320 + 32 * 1 */ := #buf(32, 0) ]              /* node: bytes32 = zero_bytes32 */
+    [ 384 /* = 320 + 32 * 2 */ := #buf(32, DEPOSIT_COUNT) ]  /* size: uint256 = self.deposit_count */
+    [ 416 /* = 320 + 32 * 3 */ := #buf(32, 0) ]              /* height = 0 */
+
+[get_deposit_root-init]
+pc: 0 => {PC_LOOPENTER}
+word_stack: .WordStack => {WORD_STACK_INIT}
+local_mem: .Map => {LOCAL_MEM_INIT}
+; gas usage = 417 = 375 + ( 42 = 3*n + n^2 / 512 where n = 14 = 448 / 32 )
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => 448, .Set)
+GAS_COST: 400
+
+[get_deposit_root-loop0]
+pc: {PC_LOOPENTER} => {PC_LOOPHEAD}
+word_stack: {WORD_STACK_INIT} => 1 : {WORD_STACK_INIT}
+
+[get_deposit_root-loop0-then]
+local_mem: {LOCAL_MEM_INIT} => {LOCAL_MEM_INIT}
+    [ 192 /* scratchpad      */ := #buf(32, 0) ]                              /* branch storage index = 0 */
+    [ 608 /* = 320 + 32 *  9 */ := #buf(32, {BRANCH_0}) ]                     /* branch[0] */
+    [ 640 /* = 320 + 32 * 10 */ := #buf(32, 0) ]                              /* node */
+    [ 576 /* = 320 + 32 *  8 */ := #buf(32, 64) ]                             /* size of sha256 input */
+    [ 192 /* scratchpad      */ := #buf(32, {NODE_1}) ]                       /* sha256 return value via sha256(608, 64) */
+    [ 352 /* = 320 + 32 *  1 */ := #buf(32, {NODE_1}) ]                       /* update node = sha256(branch[0], node) */
+    [ 384 /* = 320 + 32 *  2 */ := #buf(32, DEPOSIT_COUNT /Int 2) ]           /* update size */
+    [ 416 /* = 320 + 32 *  3 */ := #buf(32, 1) ]                              /* update height */
+BRANCH_0: select(M, #hashedLocation({COMPILER}, {BRANCH}, 0))
+NODE_1: #sha256(#buf(32, {BRANCH_0}) ++ #buf(32, 0))
++requires:
+    // conditions
+    andBool DEPOSIT_COUNT &Int 1 ==Int 1
+; gas usage = 1766 = 1703 + ( 63 = 3*n + n^2 / 512 where n = 21 = 672 / 32 )
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(448 => 672, .Set)
+GAS_COST: 1328
+
+[get_deposit_root-loop0-else]
+local_mem: {LOCAL_MEM_INIT} => {LOCAL_MEM_INIT}
+    [ 480 /* = 320 + 32 *  5 */ := #buf(32, 0) ]                              /* node */
+    [ 192 /* scratchpad      */ := #buf(32, 2) ]                              /* zero_hashes storage index = 2 */
+    [ 512 /* = 320 + 32 *  6 */ := #buf(32, {ZERO_HASHES_0}) ]                /* zero_hashes[0] */
+    [ 448 /* = 320 + 32 *  4 */ := #buf(32, 64) ]                             /* size of sha256 input */
+    [ 192 /* scratchpad      */ := #buf(32, {NODE_1}) ]                       /* sha256 return value via sha256(480, 64) */
+    [ 352 /* = 320 + 32 *  1 */ := #buf(32, {NODE_1}) ]                       /* update node = sha256(node, zero_hashes[0]) */
+    [ 384 /* = 320 + 32 *  2 */ := #buf(32, DEPOSIT_COUNT /Int 2) ]           /* update size */
+    [ 416 /* = 320 + 32 *  3 */ := #buf(32, 1) ]                              /* update height */
+ZERO_HASHES_0: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, 0))
+NODE_1: #sha256(#buf(32, 0) ++ #buf(32, {ZERO_HASHES_0}))
++requires:
+    // conditions
+    andBool DEPOSIT_COUNT &Int 1 =/=Int 1
+; gas usage = 1744 = 1693 + ( 51 = 3*n + n^2 / 512 where n = 17 = 544 / 32 )
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(448 => 544, .Set)
+GAS_COST: 1318
+
+[get_deposit_root-loop]
+; MEMORY_USED_LOOPHEAD: 17 or 21
+LOCAL_MEM_LOOPHEAD: {LOCAL_MEM_BEGIN}
+    ; locals
+    [ 320 /* = 320 + 32 *  0 */ := #buf(32, 0) ]          /* zero_bytes32: bytes32 = 0x0 */
+    [ 352 /* = 320 + 32 *  1 */ := #buf(32, NODE) ]       /* node: bytes32 */
+    [ 384 /* = 320 + 32 *  2 */ := #buf(32, SIZE) ]       /* size: uint256 */
+    [ 416 /* = 320 + 32 *  3 */ := #buf(32, HEIGHT) ]     /* height */
+    ; garbages
+    [ 192 /* scratchpad      */ := #buf(32, ANON_1) ]     /* sha256 return value */
+    // for if-then branch
+    [ 576 /* = 320 + 32 *  8 */ := #buf(32, ANON_2) ]     /* size of sha256 input */
+    [ 608 /* = 320 + 32 *  9 */ := #buf(32, ANON_3) ]     /* branch[height] */
+    [ 640 /* = 320 + 32 * 10 */ := #buf(32, ANON_4) ]     /* node */
+    // for if-else branch
+    [ 448 /* = 320 + 32 *  4 */ := #buf(32, ANON_5) ]     /* size of sha256 input */
+    [ 480 /* = 320 + 32 *  5 */ := #buf(32, ANON_6) ]     /* node */
+    [ 512 /* = 320 + 32 *  6 */ := #buf(32, ANON_7) ]     /* zero_hashes[height] */
++requires:
+    // conditions
+    andBool #range(0 <= HEIGHT <= 32)
+    // types
+    andBool #rangeUInt(256, NODE)
+    andBool #rangeUInt(256, SIZE)
+    andBool #rangeUInt(256, ANON_1)
+    andBool #rangeUInt(256, ANON_2)
+    andBool #rangeUInt(256, ANON_3)
+    andBool #rangeUInt(256, ANON_4)
+    andBool #rangeUInt(256, ANON_5)
+    andBool #rangeUInt(256, ANON_6)
+    andBool #rangeUInt(256, ANON_7)
+
+[get_deposit_root-loop-body]
+pc: {PC_LOOPHEAD}
+word_stack: (HEIGHT => HEIGHT +Int 1) : {WORD_STACK_INIT}
++requires:
+    // conditions
+    andBool HEIGHT <Int 32
+
+[get_deposit_root-loop-body-then]
+local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
+    [ 192 /* scratchpad      */ := #buf(32, 0) ]                      /* branch storage index = 0 */
+    [ 608 /* = 320 + 32 *  9 */ := #buf(32, {BRANCH_HEIGHT}) ]        /* branch[height] */
+    [ 640 /* = 320 + 32 * 10 */ := #buf(32, NODE) ]                   /* node */
+    [ 576 /* = 320 + 32 *  8 */ := #buf(32, 64) ]                     /* size of sha256 input */
+    [ 192 /* scratchpad      */ := #buf(32, {NODE_NEW}) ]             /* sha256 return value */
+    [ 352 /* = 320 + 32 *  1 */ := #buf(32, {NODE_NEW}) ]             /* update node */
+    [ 384 /* = 320 + 32 *  2 */ := #buf(32, SIZE /Int 2) ]            /* update size */
+    [ 416 /* = 320 + 32 *  3 */ := #buf(32, HEIGHT +Int 1) ]          /* update height */
+BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
+NODE_NEW: #sha256(#buf(32, {BRANCH_HEIGHT}) ++ #buf(32, NODE))
++requires:
+    // conditions
+    andBool SIZE &Int 1 ==Int 1
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(672, .Set)
+GAS_COST: 1350
+
+[get_deposit_root-loop-body-else]
+local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
+    [ 480 /* = 320 + 32 *  5 */ := #buf(32, NODE) ]                   /* node */
+    [ 192 /* scratchpad      */ := #buf(32, 2) ]                      /* zero_hashes storage index = 2 */
+    [ 512 /* = 320 + 32 *  6 */ := #buf(32, {ZERO_HASHES_HEIGHT}) ]   /* zero_hashes[height] */
+    [ 448 /* = 320 + 32 *  4 */ := #buf(32, 64) ]                     /* size of sha256 input */
+    [ 192 /* scratchpad      */ := #buf(32, {NODE_NEW}) ]             /* sha256 return value via sha256(480, 64) */
+    [ 352 /* = 320 + 32 *  1 */ := #buf(32, {NODE_NEW}) ]             /* update node = sha256(node, zero_hashes[height]) */
+    [ 384 /* = 320 + 32 *  2 */ := #buf(32, SIZE /Int 2) ]            /* update size = size / 2 */
+    [ 416 /* = 320 + 32 *  3 */ := #buf(32, HEIGHT +Int 1) ]          /* update height = height + 1 */
+ZERO_HASHES_HEIGHT: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, HEIGHT))
+NODE_NEW: #sha256(#buf(32, NODE) ++ #buf(32, {ZERO_HASHES_HEIGHT}))
++requires:
+    // conditions
+    andBool SIZE &Int 1 =/=Int 1
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(672, .Set)
+GAS_COST: 1340
+
+[get_deposit_root-loop-exit]
+k: #execute => #halt
+status_code: _ => EVMC_SUCCESS
+pc: {PC_LOOPHEAD} => {PC_END}
+RETURN_VAL: #sha256(#buf(32, NODE) ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0))
+output: _ => #buf(32, {RETURN_VAL})
+word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
+local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
+    ; preparing for calling to_little_endian_64
+    [ 1152 /* = 1120 + 32 *  1     */ := #buf(32, NODE) ]
+    [  736 /* =  320 + 32 * 13     */ := #buf(32, 2154246793) ]            /* 0x80673289 */ /* ??? */
+    [  768 /* =  320 + 32 * 14     */ := #buf(32, DEPOSIT_COUNT) ]
+    ; call to_little_endian_64 (pc: 1013 -> [155 -> ... -> 628] -> 1014)
+    {LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
+    ; finish
+    [  864 /* =  320 + 32 * 17     */ := #buf(32, 8) ]
+    [  960 /* =  320 + 32 * 20     */ := #buf(32, 0) ]
+    [  896 /* =  320 + 32 * 18     */ := #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0) ]
+    [  960 /* =  320 + 32 * 20     */ := #buf(32, 32) ]
+    [  384 /* =  320 + 32 *  2     */ := #buf(32, SIZE) ]                  /* restore size: uint256 */
+    [  352 /* =  320 + 32 *  1     */ := #buf(32, NODE) ]                  /* restore node: bytes32 */
+    [  320 /* =  320 + 32 *  0     */ := #buf(32, 0) ]                     /* restore zero_bytes32: bytes32 */
+    [ 1184 /* = 1120 + 32 *  2     */ := #bufSeg(#buf(32, Y8), 24, 8) ]    /* self.to_little_endian_64(self.deposit_count) */  /* via memcpy(1152 <- 864,  8) */
+    [ 1024 /* =  320 + 32 * 22     */ := #buf(32, 0) ]                     /* zero_bytes32 */                                  /* via memcpy( 992 <- 320, 32) */
+    [  992 /* =  320 + 32 * 21     */ := #buf(32, 24) ]                    /* slice len */
+    [ 1192 /* = 1120 + 32 *  2 + 8 */ := #buf(24, 0) ]                     /* slice(zero_bytes32, start=0, len=24) */          /* via memcpy(1160 <- 992, 24) */
+    [ 1120 /* = 1120 + 32 *  0     */ := #buf(32, 64) ]
+    [  192 /* scratchpad           */ := #buf(32, {RETURN_VAL}) ]          /* via sha256(1120, 64) */
+    [    0                            := #buf(32, {RETURN_VAL}) ]          /* return sha256(concat(node, self.to_little_endian_64(self.deposit_count), slice(zero_bytes32, start=0, len=24))) */
+RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64: 1039
++requires:
+    // conditions
+    andBool HEIGHT ==Int 32
+    {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(672 => 1216, .Set)
+GAS_COST: 11385
+
+;
+; get_deposit_count
+;
+
+[get_deposit_count]
+; The term `#buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)` models certain extra call-data added accidently or intentionally.
+; This ensures that the function works correctly even in such a case.
+call_data: #abiCallData("get_deposit_count", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)
+storage: M
++requires:
+    // conditions
+    andBool CALL_VALUE ==Int 0
+    // types
+    andBool #rangeUInt(256, DEPOSIT_COUNT)
+    andBool isStorage(M)
+    // let-bindings
+    andBool DEPOSIT_COUNT ==Int select(M, #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList))
+    {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
+LOCAL_MEM_BEGIN: .Map
+    ; function hash
+    [  28 := 98 : 31 : 209 : 48 : #take(28, #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)) ]
+    {VYPER_GENERATED_BOUNDS}
+k: #execute => #halt
+status_code: _ => EVMC_SUCCESS
+pc: 0 => 1561
+output: _ => #encodeArgs(#bytes(#bufSeg(#buf(32, Y8), 24, 8)))
+; output: _ => #buf(32, 32) ++ #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0)
+;            ; 608             640            672                             680         704
+word_stack: .WordStack
+local_mem: .Map => {LOCAL_MEM_BEGIN}
+    ; before call
+    [ 320 /* = 320 + 32 *  0      */ := #buf(32, 2154246793) ]     /* 0x80673289 */ /* ??? */
+    [ 352 /* = 320 + 32 *  1      */ := #buf(32, DEPOSIT_COUNT) ]
+    ; call to_little_endian_64
+    {LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
+    ; after call
+    [ 448 /* = 320 + 32 *  4      */ := #buf(32, 8) ]
+    [ 544 /* = 320 + 32 *  7      */ := #buf(32, 0) ]
+    [ 480 /* = 320 + 32 *  5      */ := #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0) ]  /* return value from to_little_endian_64 */
+    [ 544 /* = 320 + 32 *  7      */ := #buf(32, 32) ]
+    [ 640 /* = 320 + 32 * 10      */ := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ]  /* memcpy(640 <- 448, 40) */
+    [ 736 /* = 320 + 32 * 13      */ := #buf(32, 32) ]                                 /* zero padding loop index */
+    [ 680 /* = 320 + 32 * 11 +  8 */ <- 0 ]                                            /* zero padding */
+    [ 681 /* = 320 + 32 * 11 +  9 */ <- 0 ]
+    [ 682 /* = 320 + 32 * 11 + 10 */ <- 0 ]
+    [ 683 /* = 320 + 32 * 11 + 11 */ <- 0 ]
+    [ 684 /* = 320 + 32 * 11 + 12 */ <- 0 ]
+    [ 685 /* = 320 + 32 * 11 + 13 */ <- 0 ]
+    [ 686 /* = 320 + 32 * 11 + 14 */ <- 0 ]
+    [ 687 /* = 320 + 32 * 11 + 15 */ <- 0 ]
+    [ 688 /* = 320 + 32 * 11 + 16 */ <- 0 ]
+    [ 689 /* = 320 + 32 * 11 + 17 */ <- 0 ]
+    [ 690 /* = 320 + 32 * 11 + 18 */ <- 0 ]
+    [ 691 /* = 320 + 32 * 11 + 19 */ <- 0 ]
+    [ 692 /* = 320 + 32 * 11 + 20 */ <- 0 ]
+    [ 693 /* = 320 + 32 * 11 + 21 */ <- 0 ]
+    [ 694 /* = 320 + 32 * 11 + 22 */ <- 0 ]
+    [ 695 /* = 320 + 32 * 11 + 23 */ <- 0 ]
+    [ 696 /* = 320 + 32 * 11 + 24 */ <- 0 ]
+    [ 697 /* = 320 + 32 * 11 + 25 */ <- 0 ]
+    [ 698 /* = 320 + 32 * 11 + 26 */ <- 0 ]
+    [ 699 /* = 320 + 32 * 11 + 27 */ <- 0 ]
+    [ 700 /* = 320 + 32 * 11 + 28 */ <- 0 ]
+    [ 701 /* = 320 + 32 * 11 + 29 */ <- 0 ]
+    [ 702 /* = 320 + 32 * 11 + 30 */ <- 0 ]
+    [ 703 /* = 320 + 32 * 11 + 31 */ <- 0 ]
+    [ 608 /* = 320 + 32 *  9      */ := #buf(32, 32) ]                                 /* return(608, 96) */
+RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64: 1348
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => 832, .Set)
+GAS_COST: 11424
+
+;
+; deposit
+;
+
+[deposit]
+; #buf(32, 96) ++ #buf(32, 192) ++ #buf(32, 256)        // header
+; ++ #buf(32, 48) ++ #buf(48, PUBKEY) ++ #buf(16, 0)    // pubkey + zero-padding
+; ++ #buf(32, 32) ++ #buf(32, WITHDRAWAL_CREDENTIALS)   // withdrawal_credentials
+; ++ #buf(32, 96) ++ #buf(96, SIGNATURE)                // signature
+call_data: #abiCallData("deposit", (
+            #bytes(#buf({PUBKEY_LENGTH},                 PUBKEY)),
+            #bytes(#buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)),
+            #bytes(#buf({SIGNATURE_LENGTH},              SIGNATURE)),
+            #bytes32(DEPOSIT_DATA_ROOT) ))
+storage: M
++requires:
+    // ranges
+    andBool #range(0 <= PUBKEY                 < 2 ^Int ({PUBKEY_LENGTH}                 *Int 8))
+    andBool #range(0 <= WITHDRAWAL_CREDENTIALS < 2 ^Int ({WITHDRAWAL_CREDENTIALS_LENGTH} *Int 8))
+    andBool #range(0 <= SIGNATURE              < 2 ^Int ({SIGNATURE_LENGTH}              *Int 8))
+    andBool #rangeUInt(256, DEPOSIT_DATA_ROOT)
+    // types
+    andBool #rangeUInt(256, DEPOSIT_COUNT)
+    andBool isStorage(M)
+    // let-bindings
+    andBool DEPOSIT_COUNT ==Int select(M, #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList))
+    {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
+    {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT}
+    // conditions
+    {CONDITIONS}
+CONDITIONS:
+    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
+    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
+PUBKEY_LENGTH:                 48
+WITHDRAWAL_CREDENTIALS_LENGTH: 32
+SIGNATURE_LENGTH:              96
+MAX_DEPOSIT_COUNT:  4294967295
+GWEI_IN_WEI:        1000000000
+MIN_DEPOSIT_AMOUNT: 1000000000
+DEPOSIT_AMOUNT: (CALL_VALUE /Int {GWEI_IN_WEI})
+LOCAL_MEM_BEGIN: .Map
+    {LOCAL_MEM_DEPOSIT_FUNCTION_HASH}
+    {VYPER_GENERATED_BOUNDS}
+LOCAL_MEM_DEPOSIT_FUNCTION_HASH:
+    ; function hash
+    [  28 <-  34 ]
+    [  29 <- 137 ]
+    [  30 <-  81 ]
+    [  31 <-  24 ]
+LOCAL_MEM_INIT: {LOCAL_MEM_BEGIN}
+    ; load calldata
+    [  320 /* = 320 + 32 *  0 */ := #buf(32, 48) ++ #buf(48, PUBKEY) ]                    /* calldatacopy(416, 100,  80) */
+    [  448 /* = 320 + 32 *  4 */ := #buf(32, 32) ++ #buf(32, WITHDRAWAL_CREDENTIALS) ]    /* calldatacopy(544, 196,  64) */
+    [  544 /* = 320 + 32 *  7 */ := #buf(32, 96) ++ #buf(96, SIGNATURE) ]                 /* calldatacopy(640, 260, 128) */
+    [  736 /* = 320 + 32 * 13 */ := #buf(32, {GWEI_IN_WEI}) ]                             /* 1 gwei = 10^9 wei */
+    [  704 /* = 320 + 32 * 12 */ := #buf(32, {DEPOSIT_AMOUNT}) ]                          /* deposit_amount: uint256 = msg.value / as_wei_value(1, "gwei") */
+LOCAL_MEM_SUBCALL_1: {LOCAL_MEM_INIT}
+    ; before call
+    [  864 /* = 320 + 32 * 17 */ := #buf(32, 288) ]                                       /* memcpy loop index */
+    [  896 /* = 320 + 32 * 18 */ := #buf(32, 2154246793) ]                                /* ??? */
+    [  928 /* = 320 + 32 * 19 */ := #buf(32, {DEPOSIT_AMOUNT}) ]
+    ; call to_little_endian_64
+    {LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT}
+    ; after call
+    [ 1024 /* = 320 + 32 * 22 */ := #buf(32, 8) ]
+    [ 1120 /* = 320 + 32 * 25 */ := #buf(32, 0) ]
+    [ 1056 /* = 320 + 32 * 23 */ := #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0) ]
+    [ 1120 /* = 320 + 32 * 25 */ := #buf(32, 32) ]
+    ; restore stack
+    [  832 /* = 320 + 32 * 16 */ := #buf(32, 0) ]
+    [  800 /* = 320 + 32 * 15 */ := #buf(32, 0) ]
+    [  768 /* = 320 + 32 * 14 */ := #buf(32, 0) ]
+    [  736 /* = 320 + 32 * 13 */ := #buf(32, {GWEI_IN_WEI}) ]
+    [  704 /* = 320 + 32 * 12 */ := #buf(32, {DEPOSIT_AMOUNT}) ]
+    [  672 /* = 320 + 32 * 11 */ := #buf(32, 0) ]
+    [  640 /* = 320 + 32 * 10 */ := #bufSeg(#buf(96, SIGNATURE), 64, 32) ]
+    [  608 /* = 320 + 32 *  9 */ := #bufSeg(#buf(96, SIGNATURE), 32, 32) ]
+    [  576 /* = 320 + 32 *  8 */ := #bufSeg(#buf(96, SIGNATURE),  0, 32) ]
+    [  544 /* = 320 + 32 *  7 */ := #buf(32, 96) ]
+    [  512 /* = 320 + 32 *  6 */ := #buf(32, 0) ]
+    [  480 /* = 320 + 32 *  5 */ := #buf(32, WITHDRAWAL_CREDENTIALS) ]
+    [  448 /* = 320 + 32 *  4 */ := #buf(32, 32) ]
+    [  416 /* = 320 + 32 *  3 */ := #buf(32, 0) ]
+    [  384 /* = 320 + 32 *  2 */ := #bufSeg(#buf(48, PUBKEY), 32, 16) ++ #buf(16, 0) ]
+    [  352 /* = 320 + 32 *  1 */ := #bufSeg(#buf(48, PUBKEY),  0, 32) ]
+    [  320 /* = 320 + 32 *  0 */ := #buf(32, 48) ]
+    ; copy result
+    [  768 /* = 320 + 32 * 14 */ := #buf(32, 8) ++ #bufSeg(#buf(32, YY8), 24, 8) ]    /* memcpy(768 <- 1024, 40) */ /* amount: bytes[8] = self.to_little_endian_64(deposit_amount) */
+LOCAL_MEM_SUBCALL_2: {LOCAL_MEM_SUBCALL_1}
+    ; before call
+    [ 1152 /* = 320 + 32 * 26 */ := #buf(32, 288) ]                                       /* memcpy loop index */
+    [ 1184 /* = 320 + 32 * 27 */ := #buf(32, 2154246793) ]                                /* ??? */
+    [ 1216 /* = 320 + 32 * 28 */ := #buf(32, DEPOSIT_COUNT) ]
+    ; call to_little_endian_64
+    {LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
+    ; after call
+    [ 1312 /* = 320 + 32 * 31 */ := #buf(32, 8) ]
+    [ 1408 /* = 320 + 32 * 34 */ := #buf(32, 0) ]
+    [ 1344 /* = 320 + 32 * 32 */ := #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0) ]
+    [ 1408 /* = 320 + 32 * 34 */ := #buf(32, 32) ]
+    ; restore stack
+    [ 1120 /* = 320 + 32 * 25 */ := #buf(32, 32) ]
+    [ 1088 /* = 320 + 32 * 24 */ := #buf(32, 0) ]
+    [ 1056 /* = 320 + 32 * 23 */ := #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0) ]
+    [ 1024 /* = 320 + 32 * 22 */ := #buf(32, 8) ]
+    [  992 /* = 320 + 32 * 21 */ := #buf(32, 0) ]
+    [  960 /* = 320 + 32 * 20 */ := #buf(32, 0) ]
+    [  928 /* = 320 + 32 * 19 */ := #buf(32, {DEPOSIT_AMOUNT}) ]
+    [  896 /* = 320 + 32 * 18 */ := #buf(32, 2154246793) ]
+    [  864 /* = 320 + 32 * 17 */ := #buf(32, 288) ]
+    [  832 /* = 320 + 32 * 16 */ := #buf(32, 0) ]
+    [  800 /* = 320 + 32 * 15 */ := #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0) ]
+    [  768 /* = 320 + 32 * 14 */ := #buf(32, 8) ]
+    [  736 /* = 320 + 32 * 13 */ := #buf(32, {GWEI_IN_WEI}) ]
+    [  704 /* = 320 + 32 * 12 */ := #buf(32, {DEPOSIT_AMOUNT}) ]
+    [  672 /* = 320 + 32 * 11 */ := #buf(32, 0) ]
+    [  640 /* = 320 + 32 * 10 */ := #bufSeg(#buf(96, SIGNATURE), 64, 32) ]
+    [  608 /* = 320 + 32 *  9 */ := #bufSeg(#buf(96, SIGNATURE), 32, 32) ]
+    [  576 /* = 320 + 32 *  8 */ := #bufSeg(#buf(96, SIGNATURE),  0, 32) ]
+    [  544 /* = 320 + 32 *  7 */ := #buf(32, 96) ]
+    [  512 /* = 320 + 32 *  6 */ := #buf(32, 0) ]
+    [  480 /* = 320 + 32 *  5 */ := #buf(32, WITHDRAWAL_CREDENTIALS) ]
+    [  448 /* = 320 + 32 *  4 */ := #buf(32, 32) ]
+    [  416 /* = 320 + 32 *  3 */ := #buf(32, 0) ]
+    [  384 /* = 320 + 32 *  2 */ := #bufSeg(#buf(48, PUBKEY), 32, 16) ++ #buf(16, 0) ]
+    [  352 /* = 320 + 32 *  1 */ := #bufSeg(#buf(48, PUBKEY),  0, 32) ]
+    [  320 /* = 320 + 32 *  0 */ := #buf(32, 48) ]
+    ; copy result
+    [ 1440 /* = 320 + 32 * 35 */ := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ] /* memcpy(1440 <- 1312, 40) */
+RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT: 1864
+RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64:                2080
+LOCAL_MEM_LOG: {LOCAL_MEM_SUBCALL_2}
+    ; local memory chunk from 1632 to 2207 stores the DepositEvent log data
+    ; see [deposit-log]
+    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 160) ]                                       /* offset pointer */
+    [ 1632 /* = 1632 + 32 *  0      */ := #buf(32, 160) ]                                       /* offset to pubkey */
+    [ 1792 /* = 1632 + 32 *  5      */ := #buf(32, 48) ++ #buf(48, PUBKEY) ]                    /* pubkey */ /* memcpy(1792 <- 320, 80) */
+    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 64) ]                                        /* padding index */
+    [ 1872 /* = 1632 + 32 *  7 + 16 */ <- 0 ]
+    [ 1873 /* = 1632 + 32 *  7 + 17 */ <- 0 ]
+    [ 1874 /* = 1632 + 32 *  7 + 18 */ <- 0 ]
+    [ 1875 /* = 1632 + 32 *  7 + 19 */ <- 0 ]
+    [ 1876 /* = 1632 + 32 *  7 + 20 */ <- 0 ]
+    [ 1877 /* = 1632 + 32 *  7 + 21 */ <- 0 ]
+    [ 1878 /* = 1632 + 32 *  7 + 22 */ <- 0 ]
+    [ 1879 /* = 1632 + 32 *  7 + 23 */ <- 0 ]
+    [ 1880 /* = 1632 + 32 *  7 + 24 */ <- 0 ]
+    [ 1881 /* = 1632 + 32 *  7 + 25 */ <- 0 ]
+    [ 1882 /* = 1632 + 32 *  7 + 26 */ <- 0 ]
+    [ 1883 /* = 1632 + 32 *  7 + 27 */ <- 0 ]
+    [ 1884 /* = 1632 + 32 *  7 + 28 */ <- 0 ]
+    [ 1885 /* = 1632 + 32 *  7 + 29 */ <- 0 ]
+    [ 1886 /* = 1632 + 32 *  7 + 30 */ <- 0 ]
+    [ 1887 /* = 1632 + 32 *  7 + 31 */ <- 0 ]
+    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 256) ]
+    [ 1664 /* = 1632 + 32 *  1      */ := #buf(32, 256) ]                                       /* offset to withdrawal_credentials */
+    [ 1888 /* = 1632 + 32 *  8      */ := #buf(32, 32) ++ #buf(32, WITHDRAWAL_CREDENTIALS) ]    /* withdrawal_credentials */ /* memcpy(1888 <- 448, 64) */
+    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 32) ]                                        /* padding index */
+    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 320) ]
+    [ 1696 /* = 1632 + 32 *  2      */ := #buf(32, 320) ]                                       /* offset to amount */
+    [ 1952 /* = 1632 + 32 * 10      */ := #buf(32, 8) ++ #bufSeg(#buf(32, YY8), 24, 8) ]        /* amount */ /* memcpy(1952 <- 768, 40) */
+    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 32) ]                                        /* padding index */
+    [ 1992 /* = 1632 + 32 * 11 +  8 */ <- 0 ]
+    [ 1993 /* = 1632 + 32 * 11 +  9 */ <- 0 ]
+    [ 1994 /* = 1632 + 32 * 11 + 10 */ <- 0 ]
+    [ 1995 /* = 1632 + 32 * 11 + 11 */ <- 0 ]
+    [ 1996 /* = 1632 + 32 * 11 + 12 */ <- 0 ]
+    [ 1997 /* = 1632 + 32 * 11 + 13 */ <- 0 ]
+    [ 1998 /* = 1632 + 32 * 11 + 14 */ <- 0 ]
+    [ 1999 /* = 1632 + 32 * 11 + 15 */ <- 0 ]
+    [ 2000 /* = 1632 + 32 * 11 + 16 */ <- 0 ]
+    [ 2001 /* = 1632 + 32 * 11 + 17 */ <- 0 ]
+    [ 2002 /* = 1632 + 32 * 11 + 18 */ <- 0 ]
+    [ 2003 /* = 1632 + 32 * 11 + 19 */ <- 0 ]
+    [ 2004 /* = 1632 + 32 * 11 + 20 */ <- 0 ]
+    [ 2005 /* = 1632 + 32 * 11 + 21 */ <- 0 ]
+    [ 2006 /* = 1632 + 32 * 11 + 22 */ <- 0 ]
+    [ 2007 /* = 1632 + 32 * 11 + 23 */ <- 0 ]
+    [ 2008 /* = 1632 + 32 * 11 + 24 */ <- 0 ]
+    [ 2009 /* = 1632 + 32 * 11 + 25 */ <- 0 ]
+    [ 2010 /* = 1632 + 32 * 11 + 26 */ <- 0 ]
+    [ 2011 /* = 1632 + 32 * 11 + 27 */ <- 0 ]
+    [ 2012 /* = 1632 + 32 * 11 + 28 */ <- 0 ]
+    [ 2013 /* = 1632 + 32 * 11 + 29 */ <- 0 ]
+    [ 2014 /* = 1632 + 32 * 11 + 30 */ <- 0 ]
+    [ 2015 /* = 1632 + 32 * 11 + 31 */ <- 0 ]
+    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 384) ]
+    [ 1728 /* = 1632 + 32 *  3      */ := #buf(32, 384) ]                                       /* offset to signature */
+    [ 2016 /* = 1632 + 32 * 12      */ := #buf(32, 96) ++ #buf(96, SIGNATURE) ]                 /* signature */ /* memcpy(<- 544, 128) */
+    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 96) ]                                        /* padding index */
+    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 512) ]
+    [ 1760 /* = 1632 + 32 *  4      */ := #buf(32, 512) ]                                       /* offset to deposit_count */
+    [ 2144 /* = 1632 + 32 * 16      */ := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ]         /* deposit_count */ /* memcpy(<- 1440, 40) */
+    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 32) ]                                        /* padding index */
+    [ 2184 /* = 1632 + 32 * 17 +  8 */ <- 0 ]
+    [ 2185 /* = 1632 + 32 * 17 +  9 */ <- 0 ]
+    [ 2186 /* = 1632 + 32 * 17 + 10 */ <- 0 ]
+    [ 2187 /* = 1632 + 32 * 17 + 11 */ <- 0 ]
+    [ 2188 /* = 1632 + 32 * 17 + 12 */ <- 0 ]
+    [ 2189 /* = 1632 + 32 * 17 + 13 */ <- 0 ]
+    [ 2190 /* = 1632 + 32 * 17 + 14 */ <- 0 ]
+    [ 2191 /* = 1632 + 32 * 17 + 15 */ <- 0 ]
+    [ 2192 /* = 1632 + 32 * 17 + 16 */ <- 0 ]
+    [ 2193 /* = 1632 + 32 * 17 + 17 */ <- 0 ]
+    [ 2194 /* = 1632 + 32 * 17 + 18 */ <- 0 ]
+    [ 2195 /* = 1632 + 32 * 17 + 19 */ <- 0 ]
+    [ 2196 /* = 1632 + 32 * 17 + 20 */ <- 0 ]
+    [ 2197 /* = 1632 + 32 * 17 + 21 */ <- 0 ]
+    [ 2198 /* = 1632 + 32 * 17 + 22 */ <- 0 ]
+    [ 2199 /* = 1632 + 32 * 17 + 23 */ <- 0 ]
+    [ 2200 /* = 1632 + 32 * 17 + 24 */ <- 0 ]
+    [ 2201 /* = 1632 + 32 * 17 + 25 */ <- 0 ]
+    [ 2202 /* = 1632 + 32 * 17 + 26 */ <- 0 ]
+    [ 2203 /* = 1632 + 32 * 17 + 27 */ <- 0 ]
+    [ 2204 /* = 1632 + 32 * 17 + 28 */ <- 0 ]
+    [ 2205 /* = 1632 + 32 * 17 + 29 */ <- 0 ]
+    [ 2206 /* = 1632 + 32 * 17 + 30 */ <- 0 ]
+    [ 2207 /* = 1632 + 32 * 17 + 31 */ <- 0 ]
+    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 576) ]                                       /* offset pointer = size of log data */
+LOCAL_MEM_DATA: {LOCAL_MEM_LOG}
+    ; see [deposit-data]
+    [ 1792 := #buf(32, 0) ]                             /* zero_bytes32: bytes32 = 0x0000000000000000000000000000000000000000000000000000000000000000 */
+    ; compute pubkey_root
+    [ 2016 := #buf(48, PUBKEY) ]                        /* memcpy(<- 352, 48) */
+    [ 1888 := #buf(32, 0) ]                             /* memcpy(<- 1792, 32) */
+    [ 1856 := #buf(32, 16) ]                            /* len=64 - PUBKEY_LENGTH */
+    [ 2064 := #buf(16, 0) ]                             /* memcpy(<- 1888, 16) */
+    [ 1984 := #buf(32, 64) ]
+    [  192 := #buf(32, {PUBKEY_ROOT}) ]                 /* sha256(2016, 64) */
+    [ 1824 := #buf(32, {PUBKEY_ROOT}) ]                 /* pubkey_root: bytes32 = sha256(concat(pubkey, slice(zero_bytes32, start=0, len=64 - PUBKEY_LENGTH))) */
+    ; compute tmp1
+    [ 2176 := #buf(96, SIGNATURE) ]                     /* memcpy(<- 576, 96) */
+    [ 2144 := #buf(32, 64) ]
+    [  192 := #buf(32, {TMP1}) ]                        /* sha256(2176, 64) */
+    [ 2688 := #buf(32, {TMP1}) ]                        /* sha256(slice(signature, start=0, len=64)), */
+    ; compute tmp2
+    [ 2368 := #bufSeg(#buf(96, SIGNATURE), 64, 32) ++ #buf(32, 0) ++ #buf(32, {DEPOSIT_AMOUNT}) ]   /* memcpy(<- 640, 96) */   /* TODO: ??? */
+    [ 2336 := #buf(32, 32) ]                            /* len=SIGNATURE_LENGTH - 64 */
+    [ 2560 := #bufSeg(#buf(96, SIGNATURE), 64, 32) ]    /* memcpy(<- 2368, 32) */
+    [ 2592 := #buf(32, 0) ]
+    [ 2528 := #buf(32, 64) ]
+    [  192 := #buf(32, {TMP2}) ]                        /* sha256(2560, 64) */
+    [ 2720 := #buf(32, {TMP2}) ]                        /* sha256(concat(slice(signature, start=64, len=SIGNATURE_LENGTH - 64), zero_bytes32)), */
+    ; compute signature_root
+    [ 2656 := #buf(32, 64) ]
+    [  192 := #buf(32, {SIGNATURE_ROOT}) ]              /* sha256(2688, 64) */
+    [ 2112 := #buf(32, {SIGNATURE_ROOT}) ]              /* signature_root: bytes32 = sha256(concat(...)) */
+    ; compute tmp3
+    [ 2848 := #buf(32, {PUBKEY_ROOT}) ]
+    [ 2880 := #buf(32, WITHDRAWAL_CREDENTIALS) ]        /* memcpy(<- 480, 32) */
+    [ 2816 := #buf(32, 64) ]
+    [  192 := #buf(32, {TMP3}) ]                        /* sha256(2848, 64) */
+    [ 3232 := #buf(32, {TMP3}) ]                        /* sha256(concat(pubkey_root, withdrawal_credentials)), */
+    ; compute tmp4
+    [ 3104 := #bufSeg(#buf(32, YY8), 24, 8) ]           /* memcpy(<- 800, 8) */
+    [ 2976 := #buf(32, 0) ]                             /* memcpy(<- 1792, 32) */
+    [ 2944 := #buf(32, 24) ]                            /* len=32 - AMOUNT_LENGTH */
+    [ 3112 := #buf(24, 0) ]                             /* memcpy(<- 2976, 24) */
+    [ 3136 := #buf(32, {SIGNATURE_ROOT}) ]
+    [ 3072 := #buf(32, 64) ]
+    [  192 := #buf(32, {TMP4}) ]                        /* sha256(3104, 64) */
+    [ 3264 := #buf(32, {TMP4}) ]                        /* sha256(concat(amount, slice(zero_bytes32, start=0, len=32 - AMOUNT_LENGTH), signature_root)), */
+    ; compute node
+    [ 3200 := #buf(32, 64) ]
+    [  192 := #buf(32, {NODE}) ]                        /* sha256(3232, 64) */
+    [ 2784 := #buf(32, {NODE}) ]                        /* node: bytes32 = sha256(concat(...)) */
+PUBKEY_ROOT: #sha256(#buf(48, PUBKEY) ++ #buf(16, 0))
+TMP1: #sha256(#bufSeg(#buf(96, SIGNATURE), 0, 64))
+TMP2: #sha256(#bufSeg(#buf(96, SIGNATURE), 64, 32) ++ #buf(32, 0))
+SIGNATURE_ROOT: #sha256(#buf(32, {TMP1}) ++ #buf(32, {TMP2}))
+TMP3: #sha256(#buf(32, {PUBKEY_ROOT}) ++ #buf(32, WITHDRAWAL_CREDENTIALS))
+TMP4: #sha256(#bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0) ++ #buf(32, {SIGNATURE_ROOT}))
+NODE: #sha256(#buf(32, {TMP3}) ++ #buf(32, {TMP4}))
+PC_SUBCALL_1:    1792
+PC_SUBCALL_2:    2010
+PC_LOG:          2226
+PC_DATA:         3143
+PC_ADD_BEGIN:    4020
+PC_ADD_LOOPHEAD: 4260
+PC_ADD_END:      4270
+MU_INIT:          768
+MU_SUBCALL_1:    1152
+MU_SUBCALL_2:    1480
+MU_LOG:          2208
+MU_DATA:         3296
+MU_ADD_ODD:      3392
+MU_ADD_EVEN:     3488
+
+; @payable
+; @public
+; def deposit(pubkey: bytes[PUBKEY_LENGTH],
+;             withdrawal_credentials: bytes[WITHDRAWAL_CREDENTIALS_LENGTH],
+;             signature: bytes[SIGNATURE_LENGTH],
+;             deposit_data_root: bytes32):
+;
+;     # Avoid overflowing the Merkle tree (and prevent edge case in computing `self.branch`)
+;     assert self.deposit_count < MAX_DEPOSIT_COUNT
+;
+;     # Validate deposit data
+;     deposit_amount: uint256 = msg.value / as_wei_value(1, "gwei")
+;     assert deposit_amount >= MIN_DEPOSIT_AMOUNT
+;     assert len(pubkey) == PUBKEY_LENGTH
+;     assert len(withdrawal_credentials) == WITHDRAWAL_CREDENTIALS_LENGTH
+;     assert len(signature) == SIGNATURE_LENGTH
+
+[deposit-init]
+pc: 0 => {PC_SUBCALL_1}
+word_stack: .WordStack
+local_mem: .Map => {LOCAL_MEM_INIT}
+; gas usage = 765 + ( 82 = 3*n + n^2 / 512 where n = 27 = 864 / 32 )
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MU_INIT}, .Set)
+GAS_COST: 769
+
+[deposit-init-revert-1]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+pc: 0 => 1691
+word_stack: .WordStack => _
+local_mem: .Map => _
+CONDITIONS:
+    // conditions
+    andBool DEPOSIT_COUNT >=Int {MAX_DEPOSIT_COUNT}
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MEM_COST}, .Set)
+GAS_COST: 620
+MEM_COST: 672
+
+[deposit-init-revert-2]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+pc: 0 => 1743
+word_stack: .WordStack => _
+local_mem: .Map => _
+CONDITIONS:
+    // conditions
+    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
+    andBool CALL_VALUE /Int {GWEI_IN_WEI} <Int {MIN_DEPOSIT_AMOUNT}
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MEM_COST}, .Set)
+GAS_COST: 697
+MEM_COST: 768
+
+; without calldata well-formedness condition
+
+[deposit-init-calldata]
+call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
+LOCAL_MEM_DEPOSIT_FUNCTION_HASH:
+    [   28 := {CALLDATALOAD_0} ]
+LOCAL_MEM_INIT: {LOCAL_MEM_BEGIN}
+    ; load calldata
+    [  320 := {PUBKEY_ARRAY} ]
+    [  448 := {WITHDRAWAL_CREDENTIALS_ARRAY} ]
+    [  544 := {SIGNATURE_ARRAY} ]
+    [  736 := #buf(32, {GWEI_IN_WEI}) ]                             /* 1 gwei = 10^9 wei */
+    [  704 := #buf(32, {DEPOSIT_AMOUNT}) ]                          /* deposit_amount: uint256 = msg.value / as_wei_value(1, "gwei") */
++requires:
+    // conditions
+    andBool {FUNCTION_SELECTOR} ==Int 579424536 /* 0x22895118 deposit */
+    andBool CALL_DATA_SIZE >=Int 4
+    {LENGTH_CHECK}
+LENGTH_CHECK:
+    andBool {PUBKEY_ARRAY_SIZE}                 ==Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE} ==Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}              ==Int {SIGNATURE_LENGTH}
+CALLDATALOAD_0: #take(32, {CALL_DATA})
+FUNCTION_SELECTOR: #asWord(#take(4, {CALLDATALOAD_0}))
+;
+PUBKEY_OFFSET:                 (4 +Word #asWord({CALL_DATA}[  4 .. 32 ]))
+WITHDRAWAL_CREDENTIALS_OFFSET: (4 +Word #asWord({CALL_DATA}[ 36 .. 32 ]))
+SIGNATURE_OFFSET:              (4 +Word #asWord({CALL_DATA}[ 68 .. 32 ]))
+;
+PUBKEY_ARRAY:                 ({CALL_DATA}[ {PUBKEY_OFFSET}                 .. (32 +Int {PUBKEY_LENGTH}                ) ])
+WITHDRAWAL_CREDENTIALS_ARRAY: ({CALL_DATA}[ {WITHDRAWAL_CREDENTIALS_OFFSET} .. (32 +Int {WITHDRAWAL_CREDENTIALS_LENGTH}) ])
+SIGNATURE_ARRAY:              ({CALL_DATA}[ {SIGNATURE_OFFSET}              .. (32 +Int {SIGNATURE_LENGTH}             ) ])
+;
+PUBKEY_ARRAY_SIZE:                 #asWord(#take(32, {PUBKEY_ARRAY}))
+WITHDRAWAL_CREDENTIALS_ARRAY_SIZE: #asWord(#take(32, {WITHDRAWAL_CREDENTIALS_ARRAY}))
+SIGNATURE_ARRAY_SIZE:              #asWord(#take(32, {SIGNATURE_ARRAY}))
+
+[deposit-init-calldata-revert]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+word_stack: .WordStack => _
+local_mem: .Map => _
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MEM_COST}, .Set)
+
+[deposit-init-calldata-revert-1]
+pc: 0 => 1609
+LENGTH_CHECK:
+    andBool {PUBKEY_ARRAY_SIZE}                   >Int {PUBKEY_LENGTH}
+GAS_COST: 261
+MEM_COST: 400
+
+[deposit-init-calldata-revert-2]
+pc: 0 => 1641
+LENGTH_CHECK:
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}   >Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+GAS_COST: 326
+MEM_COST: 512
+
+[deposit-init-calldata-revert-3]
+pc: 0 => 1673
+LENGTH_CHECK:
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}                >Int {SIGNATURE_LENGTH}
+GAS_COST: 397
+MEM_COST: 672
+
+[deposit-init-calldata-revert-4]
+pc: 0 => 1759
+LENGTH_CHECK:
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
+    andBool {PUBKEY_ARRAY_SIZE}                 =/=Int {PUBKEY_LENGTH}
+GAS_COST: 723
+MEM_COST: 768
+
+[deposit-init-calldata-revert-5]
+pc: 0 => 1775
+LENGTH_CHECK:
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
+    andBool {PUBKEY_ARRAY_SIZE}                  ==Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE} =/=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+GAS_COST: 749
+MEM_COST: 768
+
+[deposit-init-calldata-revert-6]
+pc: 0 => 1791
+LENGTH_CHECK:
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
+    andBool {PUBKEY_ARRAY_SIZE}                  ==Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  ==Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}              =/=Int {SIGNATURE_LENGTH}
+GAS_COST: 775
+MEM_COST: 768
+
+;    # Emit `DepositEvent` log
+;    amount: bytes[8] = self.to_little_endian_64(deposit_amount)
+;    log.DepositEvent(pubkey, withdrawal_credentials, amount, signature, self.to_little_endian_64(self.deposit_count))
+
+[deposit-subcall_1]
+pc: {PC_SUBCALL_1} => {PC_SUBCALL_2}
+word_stack: .WordStack
+local_mem: {LOCAL_MEM_INIT} => {LOCAL_MEM_SUBCALL_1}
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_INIT} => {MU_SUBCALL_1}, .Set)
+GAS_COST: 10925
+
+[deposit-subcall_2]
+pc: {PC_SUBCALL_2} => {PC_LOG}
+word_stack: .WordStack
+local_mem: {LOCAL_MEM_SUBCALL_1} => {LOCAL_MEM_SUBCALL_2}
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_SUBCALL_1} => {MU_SUBCALL_2}, .Set)
+GAS_COST: 12354
+
+[deposit-log]
+pc: {PC_LOG} => {PC_DATA}
+word_stack: .WordStack
+local_mem: {LOCAL_MEM_SUBCALL_2} => {LOCAL_MEM_LOG}
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_SUBCALL_2} => {MU_LOG}, .Set)
+GAS_COST: 17029
+log: _:List ( .List => ListItem(#abiEventLog(THIS, "DepositEvent",
+            #bytes(#buf({PUBKEY_LENGTH}, PUBKEY)),
+            #bytes(#buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)),
+            #bytes(#bufSeg(#buf(32, YY8), 24, 8)),
+            #bytes(#buf({SIGNATURE_LENGTH}, SIGNATURE)),
+            #bytes(#bufSeg(#buf(32, Y8), 24, 8)) )))
+; log: _:List ( .List => ListItem({ THIS
+;                                 | ListItem(45506446345753628416285423056165511379837572639148407563471291220684748896453) /* keccak256("DepositEvent(bytes,bytes,bytes,bytes,bytes)") */
+;                                 |  #buf(32, 5 *Int 32)
+;                                 ++ #buf(32, 5 *Int 32 +Int 96)
+;                                 ++ #buf(32, 5 *Int 32 +Int 96 +Int 64)
+;                                 ++ #buf(32, 5 *Int 32 +Int 96 +Int 64 +Int 64)
+;                                 ++ #buf(32, 5 *Int 32 +Int 96 +Int 64 +Int 64 +Int 128)
+;                                 ++ #buf(32, {PUBKEY_LENGTH})                 ++ #buf({PUBKEY_LENGTH}, PUBKEY) ++ #buf(16, 0)
+;                                 ++ #buf(32, {WITHDRAWAL_CREDENTIALS_LENGTH}) ++ #buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)
+;                                 ++ #buf(32, 8)                               ++ #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0)
+;                                 ++ #buf(32, {SIGNATURE_LENGTH})              ++ #buf({SIGNATURE_LENGTH}, SIGNATURE)
+;                                 ++ #buf(32, 8)                               ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0)
+;                                 }) )
+
+;    # Compute `DepositData` hash tree root
+;    zero_bytes32: bytes32 = 0x0000000000000000000000000000000000000000000000000000000000000000
+;    pubkey_root: bytes32 = sha256(concat(pubkey, slice(zero_bytes32, start=0, len=64 - PUBKEY_LENGTH)))
+;    signature_root: bytes32 = sha256(concat(
+;        sha256(slice(signature, start=0, len=64)),                                                             <-- tmp1
+;        sha256(concat(slice(signature, start=64, len=SIGNATURE_LENGTH - 64), zero_bytes32)),                   <-- tmp2
+;    ))
+;    node: bytes32 = sha256(concat(
+;        sha256(concat(pubkey_root, withdrawal_credentials)),                                                   <-- tmp3
+;        sha256(concat(amount, slice(zero_bytes32, start=0, len=32 - AMOUNT_LENGTH), signature_root)),          <-- tmp4
+;    ))
+;    # Verify computed and expected deposit data roots match
+;    assert node == deposit_data_root
+
+; #### `DepositData`
+;
+; ```python
+; class DepositData(Container):
+;     pubkey: BLSPubkey
+;     withdrawal_credentials: Hash
+;     amount: Gwei
+;     signature: BLSSignature
+; ```
+
+;                                    ___________________________ node _________________________
+;                                   /                                                          \
+;                    __________ tmp3 ___________________                        ______________ tmp4 _______________
+;                   /                                   \                      /                                   \
+;           pubkey_root                       withdrawal_credentials       amount                        _____ signature_root __________
+;           /       \                                                                                   /                               \
+;   pubkey[0:32]  pubkey[32:48]++zero[0:16]                                                           tmp1                             tmp2
+;                                                                                                  /       \                        /        \
+;                                                                                       signature[0:32]  signature[32:64]  signature[64:96]  zero[0:32]
+
+[deposit-data]
+pc: {PC_DATA} => {PC_ADD_BEGIN}
+word_stack: .WordStack
+local_mem: {LOCAL_MEM_LOG} => {LOCAL_MEM_DATA}
++CONDITIONS:
+    // conditions
+    andBool {NODE} ==Int DEPOSIT_DATA_ROOT
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_LOG} => {MU_DATA}, .Set)
+GAS_COST: 14366
+
+[deposit-data-revert]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+pc: {PC_DATA} => 4018
+word_stack: .WordStack => _
+local_mem: {LOCAL_MEM_LOG} => _
+CONDITIONS:
+    // conditions
+    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
+    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
+    andBool {NODE} =/=Int DEPOSIT_DATA_ROOT
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_LOG} => {MU_DATA}, .Set)
+GAS_COST: 14371
+
+;    # Add `DepositData` hash tree root to Merkle tree (update a single `branch` node)
+;    self.deposit_count += 1
+;    size: uint256 = self.deposit_count
+;    for height in range(DEPOSIT_CONTRACT_TREE_DEPTH):
+;        if bitwise_and(size, 1) == 1:  # More gas efficient than `size % 2 == 1`
+;            self.branch[height] = node
+;            break
+;        node = sha256(concat(self.branch[height], node))
+;        size /= 2
+
+[deposit-add]
+WORD_STACK_INIT: 32 : 3360 : .WordStack
+
+[deposit-add-init]
+;
+
+[deposit-add-init-then]
+k: #execute => #halt
+output: _ => .WordStack
+status_code: _ => EVMC_SUCCESS
+pc: {PC_ADD_BEGIN} => {PC_ADD_END}
+word_stack: .WordStack
+local_mem: {LOCAL_MEM_DATA} => {LOCAL_MEM_DATA}
+    [ 3328 := #buf(32, DEPOSIT_COUNT +Int 1) ]          /* size: uint256 = self.deposit_count */
+    [ 3360 := #buf(32, 0) ]                             /* height */
+    [  192 := #buf(32, 0) ]
+storage: M => M
+    [ #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList) <- DEPOSIT_COUNT +Int 1 ]
+    [ #hashedLocation({COMPILER}, {BRANCH}, 0)               <- {NODE} ]
+refund: _ => _
++requires:
+    // conditions
+    andBool (DEPOSIT_COUNT +Int 1) &Int 1 ==Int 1
+gas:         #symGas(G, 0 => 11019, 0 => 41019, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_DATA} => {MU_ADD_ODD}, .Set)
+
+[deposit-add-init-else]
+pc: {PC_ADD_BEGIN} => {PC_ADD_LOOPHEAD}
+word_stack: .WordStack => 1 : {WORD_STACK_INIT}
+local_mem: {LOCAL_MEM_DATA} => {LOCAL_MEM_DATA}
+    [ 3328 := #buf(32, DEPOSIT_COUNT +Int 1) ]          /* size: uint256 = self.deposit_count */
+    [ 3360 := #buf(32, 0) ]                             /* height */
+    [  192 := #buf(32, 0) ]
+    [ 3424 := #buf(32, {BRANCH_0}) ]
+    [ 3456 := #buf(32, {NODE}) ]
+    [ 3392 := #buf(32, 64) ]
+    [  192 := #buf(32, {NODE_1}) ]                      /* sha256(3424, 64) */
+    [ 2784 := #buf(32, {NODE_1}) ]                      /* node = sha256(concat(self.branch[height], node)) */
+    [ 3328 := #buf(32, (DEPOSIT_COUNT +Int 1) /Int 2) ] /* update size */
+    [ 3360 := #buf(32, 1) ]                             /* update height */
+BRANCH_0: select(M, #hashedLocation({COMPILER}, {BRANCH}, 0))
+NODE_1: #sha256(#buf(32, {BRANCH_0}) ++ #buf(32, {NODE}))
+storage: M => M
+    [ #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList) <- DEPOSIT_COUNT +Int 1 ]
+refund: _ => _
++requires:
+    // conditions
+    andBool (DEPOSIT_COUNT +Int 1) &Int 1 =/=Int 1
+gas:         #symGas(G, 0 => 7196, 0 => 22196, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_DATA} => {MU_ADD_EVEN}, .Set)
+
+[deposit-add-loop]
+LOCAL_MEM_LOOPHEAD: {LOCAL_MEM_DATA}
+    [ 3328 := #buf(32, SIZE) ]                      /* size */
+    [ 3360 := #buf(32, HEIGHT) ]                    /* height */
+    [  192 := #buf(32, 0) ]
+    [ 3424 := #buf(32, ANON_1) ]
+    [ 3456 := #buf(32, ANON_2) ]
+    [ 3392 := #buf(32, 64) ]
+    [  192 := #buf(32, NODE) ]                      /* sha256(3456, 64) */
+    [ 2784 := #buf(32, NODE) ]                      /* node = sha256(concat(self.branch[height], node)) */
++requires:
+    // conditions
+    andBool #range(0 <= HEIGHT <= 32)
+    // types
+    andBool #rangeUInt(256, NODE)
+    andBool #rangeUInt(256, SIZE)
+    andBool #rangeUInt(256, ANON_1)
+    andBool #rangeUInt(256, ANON_2)
+
+[deposit-add-loop-enter]
++requires:
+    // conditions
+    andBool HEIGHT <Int 32
+
+[deposit-add-loop-enter-then]
+k: #execute => #halt
+output: _ => .WordStack
+status_code: _ => EVMC_SUCCESS
+pc: {PC_ADD_LOOPHEAD} => {PC_ADD_END}
+word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
+local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
+    [  192 := #buf(32, 0) ]
+storage: M => M
+    [ #hashedLocation({COMPILER}, {BRANCH}, HEIGHT) <- NODE ]
+refund: _ => _
++requires:
+    // conditions
+    andBool SIZE &Int 1 ==Int 1
+gas:         #symGas(G, 0 => 5162, 0 => 20162, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_ADD_EVEN}, .Set)
+
+[deposit-add-loop-enter-else]
+pc: {PC_ADD_LOOPHEAD}
+word_stack: (HEIGHT => HEIGHT +Int 1) : {WORD_STACK_INIT}
+local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
+    [  192 := #buf(32, 0) ]
+    [ 3424 := #buf(32, {BRANCH_HEIGHT}) ]
+    [ 3456 := #buf(32, NODE) ]
+    [ 3392 := #buf(32, 64) ]
+    [  192 := #buf(32, {NODE_NEW}) ]                    /* sha256(3456, 64) */
+    [ 2784 := #buf(32, {NODE_NEW}) ]                    /* node = sha256(concat(self.branch[height], node)) */
+    [ 3328 := #buf(32, SIZE /Int 2) ]                   /* update size */
+    [ 3360 := #buf(32, HEIGHT +Int 1) ]                 /* update height */
+BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
+NODE_NEW: #sha256(#buf(32, {BRANCH_HEIGHT}) ++ #buf(32, NODE))
++requires:
+    // conditions
+    andBool SIZE &Int 1 =/=Int 1
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_ADD_EVEN}, .Set)
+GAS_COST: 1339
+
+[deposit-add-loop-exit]
+k: #execute => #halt
+output: _ => .WordStack
+status_code: _ => EVMC_SUCCESS
+pc: {PC_ADD_LOOPHEAD} => {PC_ADD_END}
+word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
+local_mem: {LOCAL_MEM_LOOPHEAD}
++requires:
+    // conditions
+    andBool HEIGHT ==Int 32
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_ADD_EVEN}, .Set)
+GAS_COST: 27
+
+;
+; revert cases
+;
+
+[revert]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+
+; Revert if the first four bytes are invalid (or not fully provided).
+[revert-invalid_function_identifier]
+call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
+pc: 0 => 4277
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MEM_COST}, .Set)
+
+[revert-invalid_function_identifier-lt_4]
++requires:
+    // conditions
+    andBool #range(0 <= CALL_DATA_SIZE < 4)
+GAS_COST: 42
+MEM_COST: 0
+
+[revert-invalid_function_identifier-ge_4]
++requires:
+    // conditions
+    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 3321006383 /* 0xc5f2892f get_deposit_root  */
+    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 1646252336 /* 0x621fd130 get_deposit_count */
+    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 579424536  /* 0x22895118 deposit           */
+GAS_COST: 196
+MEM_COST: 192
+
+[revert-invalid_function_identifier-ge_4-lt_32]
++requires:
+    // conditions
+    andBool #range(4 <= CALL_DATA_SIZE < 32)
+
+[revert-invalid_function_identifier-ge_4-ge_32]
++requires:
+    // conditions
+    andBool CALL_DATA_SIZE >=Int 32
+
+[revert-init]
+code: {INIT_CODE}
+pc: 0 => 151
++requires:
+    // conditions
+    andBool CALL_VALUE =/=Int 0
+gas:         #symGas(G, 0 => 69, 0 => 69, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => 192, .Set)
+
+[revert-get_deposit_root]
+call_data: #abiCallData("get_deposit_root", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)
+pc: 0 => 663
++requires:
+    // conditions
+    andBool CALL_VALUE =/=Int 0
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => 192, .Set)
+GAS_COST: 154
+
+[revert-get_deposit_count]
+call_data: #abiCallData("get_deposit_count", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)
+pc: 0 => 1318
++requires:
+    // conditions
+    andBool CALL_VALUE =/=Int 0
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => 192, .Set)
+GAS_COST: 183
+
+;
+; globals
+;
+
+[pgm]
+COMPILER: "Array"
+; Storage variables:
+; branch: bytes32[DEPOSIT_CONTRACT_TREE_DEPTH]
+; deposit_count: uint256
+; zero_hashes: bytes32[DEPOSIT_CONTRACT_TREE_DEPTH]
+BRANCH: 0
+DEPOSIT_COUNT: 1
+ZERO_HASHES: 2
+; Constants:
+; MIN_DEPOSIT_AMOUNT: constant(uint256) = 1000000000  # Gwei
+; DEPOSIT_CONTRACT_TREE_DEPTH: constant(uint256) = 32
+; MAX_DEPOSIT_COUNT: constant(uint256) = 4294967295 # 2**DEPOSIT_CONTRACT_TREE_DEPTH - 1
+; PUBKEY_LENGTH: constant(uint256) = 48  # bytes
+; WITHDRAWAL_CREDENTIALS_LENGTH: constant(uint256) = 32  # bytes
+; AMOUNT_LENGTH: constant(uint256) = 8  # bytes
+; SIGNATURE_LENGTH: constant(uint256) = 96  # bytes
+DEPOSIT_CONTRACT_TREE_DEPTH: 32
+; bytecode
+RUNTIME_CODE: "0x600436101561000d576110b0565b600035601c52740100000000000000000000000000000000000000006020526f7fffffffffffffffffffffffffffffff6040527fffffffffffffffffffffffffffffffff8000000000000000000000000000000060605274012a05f1fffffffffffffffffffffffffdabf41c006080527ffffffffffffffffffffffffed5fa0e000000000000000000000000000000000060a05260001561027f575b6101605261014052600061018052610140516101a0526101c060006008818352015b61018051600860008112156100e8578060000360020a82046100ef565b8060020a82025b905090506101805260ff6101a051166101e052610180516101e0516101805101101561011a57600080fd5b6101e0516101805101610180526101a0517ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff86000811215610163578060000360020a820461016a565b8060020a82025b905090506101a0525b81516001018083528114156100cb575b5050601860086020820661020001602082840111156101a157600080fd5b60208061022082610180600060045af15050818152809050905090508051602001806102c08284600060045af16101d757600080fd5b50506102c05160206001820306601f82010390506103206102c0516020818352015b826103205110151561020a57610226565b6000610320516102e001535b81516001018083528114156101f9575b50505060206102a05260406102c0510160206001820306601f8201039050610280525b60006102805111151561025b57610277565b602061028051036102a001516020610280510361028052610249565b610160515650005b63c5f2892f600051141561050e57341561029857600080fd5b6000610140526101405161016052600154610180526101a060006020818352015b600160016101805116141561033a5760006101a051602081106102db57600080fd5b600060c052602060c02001546020826102400101526020810190506101605160208261024001015260208101905080610240526102409050602060c0825160208401600060025af161032c57600080fd5b60c0519050610160526103a8565b6000610160516020826101c00101526020810190506101a0516020811061036057600080fd5b600260c052602060c02001546020826101c0010152602081019050806101c0526101c09050602060c0825160208401600060025af161039e57600080fd5b60c0519050610160525b61018060026103b657600080fd5b60028151048152505b81516001018083528114156102b9575b505060006101605160208261046001015260208101905061014051610160516101805163806732896102e0526001546103005261030051600658016100a9565b506103605260006103c0525b6103605160206001820306601f82010390506103c05110151561043d57610456565b6103c05161038001526103c0516020016103c05261041b565b61018052610160526101405261036060088060208461046001018260208501600060045af150508051820191505060006018602082066103e001602082840111156104a057600080fd5b60208061040082610140600060045af150508181528090509050905060188060208461046001018260208501600060045af150508051820191505080610460526104609050602060c0825160208401600060025af16104fe57600080fd5b60c051905060005260206000f350005b63621fd130600051141561061c57341561052757600080fd5b6380673289610140526001546101605261016051600658016100a9565b506101c0526000610220525b6101c05160206001820306601f8201039050610220511015156105725761058b565b610220516101e001526102205160200161022052610550565b6101c08051602001806102808284600060045af16105a857600080fd5b50506102805160206001820306601f82010390506102e0610280516020818352015b826102e0511015156105db576105f7565b60006102e0516102a001535b81516001018083528114156105ca575b5050506020610260526040610280510160206001820306601f8201039050610260f350005b632289511860005114156110af57605060043560040161014037603060043560040135111561064a57600080fd5b60406024356004016101c037602060243560040135111561066a57600080fd5b608060443560040161022037606060443560040135111561068a57600080fd5b63ffffffff6001541061069c57600080fd5b633b9aca006102e0526102e0516106b257600080fd5b6102e05134046102c052633b9aca006102c05110156106d057600080fd5b603061014051146106e057600080fd5b60206101c051146106f057600080fd5b6060610220511461070057600080fd5b610140610360525b6103605151602061036051016103605261036061036051101561072a57610708565b6380673289610380526102c0516103a0526103a051600658016100a9565b50610400526000610460525b6104005160206001820306601f8201039050610460511015156107765761078f565b6104605161042001526104605160200161046052610754565b610340610360525b61036051526020610360510361036052610140610360511015156107ba57610797565b6104008051602001806103008284600060045af16107d757600080fd5b5050610140610480525b61048051516020610480510161048052610480610480511015610803576107e1565b63806732896104a0526001546104c0526104c051600658016100a9565b50610520526000610580525b6105205160206001820306601f82010390506105805110151561084e57610867565b610580516105400152610580516020016105805261082c565b610460610480525b61048051526020610480510361048052610140610480511015156108925761086f565b6105208051602001806105a08284600060045af16108af57600080fd5b505060a061062052610620516106605261014080516020018061062051610660018284600060045af16108e157600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516040818352015b826106005110151561091e5761093f565b600061060051610620516106800101535b815160010180835281141561090d575b505050602061062051610660015160206001820306601f82010390506106205101016106205261062051610680526101c080516020018061062051610660018284600060045af161098f57600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516020818352015b82610600511015156109cc576109ed565b600061060051610620516106800101535b81516001018083528114156109bb575b505050602061062051610660015160206001820306601f820103905061062051010161062052610620516106a05261030080516020018061062051610660018284600060045af1610a3d57600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516020818352015b8261060051101515610a7a57610a9b565b600061060051610620516106800101535b8151600101808352811415610a69575b505050602061062051610660015160206001820306601f820103905061062051010161062052610620516106c05261022080516020018061062051610660018284600060045af1610aeb57600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516060818352015b8261060051101515610b2857610b49565b600061060051610620516106800101535b8151600101808352811415610b17575b505050602061062051610660015160206001820306601f820103905061062051010161062052610620516106e0526105a080516020018061062051610660018284600060045af1610b9957600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516020818352015b8261060051101515610bd657610bf7565b600061060051610620516106800101535b8151600101808352811415610bc5575b505050602061062051610660015160206001820306601f8201039050610620510101610620527f649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c561062051610660a160006107005260006101406030806020846107c001018260208501600060045af150508051820191505060006010602082066107400160208284011115610c8c57600080fd5b60208061076082610700600060045af15050818152809050905090506010806020846107c001018260208501600060045af1505080518201915050806107c0526107c09050602060c0825160208401600060025af1610cea57600080fd5b60c0519050610720526000600060406020820661086001610220518284011115610d1357600080fd5b6060806108808260206020880688030161022001600060045af1505081815280905090509050602060c0825160208401600060025af1610d5257600080fd5b60c0519050602082610a600101526020810190506000604060206020820661092001610220518284011115610d8657600080fd5b6060806109408260206020880688030161022001600060045af15050818152809050905090506020806020846109e001018260208501600060045af1505080518201915050610700516020826109e0010152602081019050806109e0526109e09050602060c0825160208401600060025af1610e0157600080fd5b60c0519050602082610a6001015260208101905080610a6052610a609050602060c0825160208401600060025af1610e3857600080fd5b60c0519050610840526000600061072051602082610b000101526020810190506101c0602080602084610b0001018260208501600060045af150508051820191505080610b0052610b009050602060c0825160208401600060025af1610e9d57600080fd5b60c0519050602082610c800101526020810190506000610300600880602084610c0001018260208501600060045af15050805182019150506000601860208206610b800160208284011115610ef157600080fd5b602080610ba082610700600060045af1505081815280905090509050601880602084610c0001018260208501600060045af150508051820191505061084051602082610c0001015260208101905080610c0052610c009050602060c0825160208401600060025af1610f6257600080fd5b60c0519050602082610c8001015260208101905080610c8052610c809050602060c0825160208401600060025af1610f9957600080fd5b60c0519050610ae052606435610ae05114610fb357600080fd5b6001805460018254011015610fc757600080fd5b6001815401815550600154610d0052610d2060006020818352015b60016001610d005116141561101757610ae051610d20516020811061100657600080fd5b600060c052602060c02001556110ab565b6000610d20516020811061102a57600080fd5b600060c052602060c0200154602082610d40010152602081019050610ae051602082610d4001015260208101905080610d4052610d409050602060c0825160208401600060025af161107b57600080fd5b60c0519050610ae052610d00600261109257600080fd5b60028151048152505b8151600101808352811415610fe2575b5050005b5b60006000fd"
+INIT_CODE: "0x740100000000000000000000000000000000000000006020526f7fffffffffffffffffffffffffffffff6040527fffffffffffffffffffffffffffffffff8000000000000000000000000000000060605274012a05f1fffffffffffffffffffffffffdabf41c006080527ffffffffffffffffffffffffed5fa0e000000000000000000000000000000000060a052341561009857600080fd5b6101406000601f818352015b600061014051602081106100b757600080fd5b600260c052602060c020015460208261016001015260208101905061014051602081106100e357600080fd5b600260c052602060c020015460208261016001015260208101905080610160526101609050602060c0825160208401600060025af161012157600080fd5b60c0519050606051600161014051018060405190131561014057600080fd5b809190121561014e57600080fd5b6020811061015b57600080fd5b600260c052602060c02001555b81516001018083528114156100a4575b505061123556600436101561000d576110b0565b600035601c52740100000000000000000000000000000000000000006020526f7fffffffffffffffffffffffffffffff6040527fffffffffffffffffffffffffffffffff8000000000000000000000000000000060605274012a05f1fffffffffffffffffffffffffdabf41c006080527ffffffffffffffffffffffffed5fa0e000000000000000000000000000000000060a05260001561027f575b6101605261014052600061018052610140516101a0526101c060006008818352015b61018051600860008112156100e8578060000360020a82046100ef565b8060020a82025b905090506101805260ff6101a051166101e052610180516101e0516101805101101561011a57600080fd5b6101e0516101805101610180526101a0517ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff86000811215610163578060000360020a820461016a565b8060020a82025b905090506101a0525b81516001018083528114156100cb575b5050601860086020820661020001602082840111156101a157600080fd5b60208061022082610180600060045af15050818152809050905090508051602001806102c08284600060045af16101d757600080fd5b50506102c05160206001820306601f82010390506103206102c0516020818352015b826103205110151561020a57610226565b6000610320516102e001535b81516001018083528114156101f9575b50505060206102a05260406102c0510160206001820306601f8201039050610280525b60006102805111151561025b57610277565b602061028051036102a001516020610280510361028052610249565b610160515650005b63c5f2892f600051141561050e57341561029857600080fd5b6000610140526101405161016052600154610180526101a060006020818352015b600160016101805116141561033a5760006101a051602081106102db57600080fd5b600060c052602060c02001546020826102400101526020810190506101605160208261024001015260208101905080610240526102409050602060c0825160208401600060025af161032c57600080fd5b60c0519050610160526103a8565b6000610160516020826101c00101526020810190506101a0516020811061036057600080fd5b600260c052602060c02001546020826101c0010152602081019050806101c0526101c09050602060c0825160208401600060025af161039e57600080fd5b60c0519050610160525b61018060026103b657600080fd5b60028151048152505b81516001018083528114156102b9575b505060006101605160208261046001015260208101905061014051610160516101805163806732896102e0526001546103005261030051600658016100a9565b506103605260006103c0525b6103605160206001820306601f82010390506103c05110151561043d57610456565b6103c05161038001526103c0516020016103c05261041b565b61018052610160526101405261036060088060208461046001018260208501600060045af150508051820191505060006018602082066103e001602082840111156104a057600080fd5b60208061040082610140600060045af150508181528090509050905060188060208461046001018260208501600060045af150508051820191505080610460526104609050602060c0825160208401600060025af16104fe57600080fd5b60c051905060005260206000f350005b63621fd130600051141561061c57341561052757600080fd5b6380673289610140526001546101605261016051600658016100a9565b506101c0526000610220525b6101c05160206001820306601f8201039050610220511015156105725761058b565b610220516101e001526102205160200161022052610550565b6101c08051602001806102808284600060045af16105a857600080fd5b50506102805160206001820306601f82010390506102e0610280516020818352015b826102e0511015156105db576105f7565b60006102e0516102a001535b81516001018083528114156105ca575b5050506020610260526040610280510160206001820306601f8201039050610260f350005b632289511860005114156110af57605060043560040161014037603060043560040135111561064a57600080fd5b60406024356004016101c037602060243560040135111561066a57600080fd5b608060443560040161022037606060443560040135111561068a57600080fd5b63ffffffff6001541061069c57600080fd5b633b9aca006102e0526102e0516106b257600080fd5b6102e05134046102c052633b9aca006102c05110156106d057600080fd5b603061014051146106e057600080fd5b60206101c051146106f057600080fd5b6060610220511461070057600080fd5b610140610360525b6103605151602061036051016103605261036061036051101561072a57610708565b6380673289610380526102c0516103a0526103a051600658016100a9565b50610400526000610460525b6104005160206001820306601f8201039050610460511015156107765761078f565b6104605161042001526104605160200161046052610754565b610340610360525b61036051526020610360510361036052610140610360511015156107ba57610797565b6104008051602001806103008284600060045af16107d757600080fd5b5050610140610480525b61048051516020610480510161048052610480610480511015610803576107e1565b63806732896104a0526001546104c0526104c051600658016100a9565b50610520526000610580525b6105205160206001820306601f82010390506105805110151561084e57610867565b610580516105400152610580516020016105805261082c565b610460610480525b61048051526020610480510361048052610140610480511015156108925761086f565b6105208051602001806105a08284600060045af16108af57600080fd5b505060a061062052610620516106605261014080516020018061062051610660018284600060045af16108e157600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516040818352015b826106005110151561091e5761093f565b600061060051610620516106800101535b815160010180835281141561090d575b505050602061062051610660015160206001820306601f82010390506106205101016106205261062051610680526101c080516020018061062051610660018284600060045af161098f57600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516020818352015b82610600511015156109cc576109ed565b600061060051610620516106800101535b81516001018083528114156109bb575b505050602061062051610660015160206001820306601f820103905061062051010161062052610620516106a05261030080516020018061062051610660018284600060045af1610a3d57600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516020818352015b8261060051101515610a7a57610a9b565b600061060051610620516106800101535b8151600101808352811415610a69575b505050602061062051610660015160206001820306601f820103905061062051010161062052610620516106c05261022080516020018061062051610660018284600060045af1610aeb57600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516060818352015b8261060051101515610b2857610b49565b600061060051610620516106800101535b8151600101808352811415610b17575b505050602061062051610660015160206001820306601f820103905061062051010161062052610620516106e0526105a080516020018061062051610660018284600060045af1610b9957600080fd5b505061062051610660015160206001820306601f82010390506106006106205161066001516020818352015b8261060051101515610bd657610bf7565b600061060051610620516106800101535b8151600101808352811415610bc5575b505050602061062051610660015160206001820306601f8201039050610620510101610620527f649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c561062051610660a160006107005260006101406030806020846107c001018260208501600060045af150508051820191505060006010602082066107400160208284011115610c8c57600080fd5b60208061076082610700600060045af15050818152809050905090506010806020846107c001018260208501600060045af1505080518201915050806107c0526107c09050602060c0825160208401600060025af1610cea57600080fd5b60c0519050610720526000600060406020820661086001610220518284011115610d1357600080fd5b6060806108808260206020880688030161022001600060045af1505081815280905090509050602060c0825160208401600060025af1610d5257600080fd5b60c0519050602082610a600101526020810190506000604060206020820661092001610220518284011115610d8657600080fd5b6060806109408260206020880688030161022001600060045af15050818152809050905090506020806020846109e001018260208501600060045af1505080518201915050610700516020826109e0010152602081019050806109e0526109e09050602060c0825160208401600060025af1610e0157600080fd5b60c0519050602082610a6001015260208101905080610a6052610a609050602060c0825160208401600060025af1610e3857600080fd5b60c0519050610840526000600061072051602082610b000101526020810190506101c0602080602084610b0001018260208501600060045af150508051820191505080610b0052610b009050602060c0825160208401600060025af1610e9d57600080fd5b60c0519050602082610c800101526020810190506000610300600880602084610c0001018260208501600060045af15050805182019150506000601860208206610b800160208284011115610ef157600080fd5b602080610ba082610700600060045af1505081815280905090509050601880602084610c0001018260208501600060045af150508051820191505061084051602082610c0001015260208101905080610c0052610c009050602060c0825160208401600060025af1610f6257600080fd5b60c0519050602082610c8001015260208101905080610c8052610c809050602060c0825160208401600060025af1610f9957600080fd5b60c0519050610ae052606435610ae05114610fb357600080fd5b6001805460018254011015610fc757600080fd5b6001815401815550600154610d0052610d2060006020818352015b60016001610d005116141561101757610ae051610d20516020811061100657600080fd5b600060c052602060c02001556110ab565b6000610d20516020811061102a57600080fd5b600060c052602060c0200154602082610d40010152602081019050610ae051602082610d4001015260208101905080610d4052610d409050602060c0825160208401600060025af161107b57600080fd5b60c0519050610ae052610d00600261109257600080fd5b60028151048152505b8151600101808352811415610fe2575b5050005b5b60006000fd5b61017f6112350361017f60003961017f611235036000f3"

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -40,7 +40,6 @@ requires:
     andBool #rangeAddress(THIS)
     andBool #rangeAddress(MSG_SENDER)
     andBool #rangeUInt(256, CALL_VALUE)
-;   andBool #rangeUInt(256, INIT_GAS)
     andBool #rangeUInt(256, INIT_BALANCE)
     andBool #rangeUInt(256, INIT_NONCE)
     andBool #rangeUInt(256, EXTRA_CALL_DATA_SIZE)
@@ -158,97 +157,126 @@ code: {INIT_CODE}
 call_data: .WordStack
 storage: .Map
 orig_storage: .Map
-; for constructor
-PC_LOOPENTER: 164
-PC_LOOPHEAD: 369
-PC_END: 4684
-WORD_STACK_INIT: 31 : 320 : .WordStack
-LOCAL_MEM_INIT: .Map
-    {VYPER_GENERATED_BOUNDS}
-    [ 320 := #buf(32, 0) ]              /* i = 0 */
 
-[init-init]
-pc: 0 => {PC_LOOPENTER}
-word_stack: .WordStack => {WORD_STACK_INIT}
-local_mem: .Map => {LOCAL_MEM_INIT}
+[init-success]
+k: #execute => #halt
+status_code: _ => EVMC_SUCCESS
+pc: 0 => 4684
+output: _ => #parseByteStack({RUNTIME_CODE})
+storage: .Map => .Map
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  1) <- ZERO_HASHES_01 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  2) <- ZERO_HASHES_02 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  3) <- ZERO_HASHES_03 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  4) <- ZERO_HASHES_04 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  5) <- ZERO_HASHES_05 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  6) <- ZERO_HASHES_06 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  7) <- ZERO_HASHES_07 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  8) <- ZERO_HASHES_08 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES},  9) <- ZERO_HASHES_09 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 10) <- ZERO_HASHES_10 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 11) <- ZERO_HASHES_11 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 12) <- ZERO_HASHES_12 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 13) <- ZERO_HASHES_13 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 14) <- ZERO_HASHES_14 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 15) <- ZERO_HASHES_15 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 16) <- ZERO_HASHES_16 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 17) <- ZERO_HASHES_17 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 18) <- ZERO_HASHES_18 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 19) <- ZERO_HASHES_19 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 20) <- ZERO_HASHES_20 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 21) <- ZERO_HASHES_21 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 22) <- ZERO_HASHES_22 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 23) <- ZERO_HASHES_23 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 24) <- ZERO_HASHES_24 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 25) <- ZERO_HASHES_25 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 26) <- ZERO_HASHES_26 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 27) <- ZERO_HASHES_27 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 28) <- ZERO_HASHES_28 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 29) <- ZERO_HASHES_29 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 30) <- ZERO_HASHES_30 ]
+    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 31) <- ZERO_HASHES_31 ]
++ensures:
+    andBool ZERO_HASHES_01 ==Int 111109925611824843164212799849330761292948257037696933205019304127221294824267
+    andBool ZERO_HASHES_02 ==Int  99208582119974435635122834636860944394611999454454139265101248405002450066801
+    andBool ZERO_HASHES_03 ==Int  90236482254272784387420235795439987838046297224132114184911355661882633139004
+    andBool ZERO_HASHES_04 ==Int  37735605373063189145609870960383397519157271673603325697615186821228299686460
+    andBool ZERO_HASHES_05 ==Int  71913990603354163933828411608472620759041242276514156984220416916786598645040
+    andBool ZERO_HASHES_06 ==Int  97950246258348409692531222476457095756697573854283095464293321272902400876449
+    andBool ZERO_HASHES_07 ==Int  61477539263323159367083172935543284935396148729545980766185719446310214598444
+    andBool ZERO_HASHES_08 ==Int  17421805441306662828813938682339723858550903736451371212309658526853237682579
+    andBool ZERO_HASHES_09 ==Int  36378541427962263534507524415416206454520492712868881526514165827410968138209
+    andBool ZERO_HASHES_10 ==Int 115790397228362049466744952478840932980575707644826095658658722282297806219563
+    andBool ZERO_HASHES_11 ==Int  49274280630555601797897865132281002146293805070798126028158380560236737348128
+    andBool ZERO_HASHES_12 ==Int  83141414795720293663742362646790664571283415314047445910275483835985445429087
+    andBool ZERO_HASHES_13 ==Int 101054748575760473813564301333136859612099677302306750615986031729334544803934
+    andBool ZERO_HASHES_14 ==Int  82118745295487409076436877854822273376925616082029112448942904331137821783940
+    andBool ZERO_HASHES_15 ==Int  96163225932810885736266036029917445088819617531019675867068430475668935471803
+    andBool ZERO_HASHES_16 ==Int  65088336600655240038095685796880324455992690470134814168105519136673920265195
+    andBool ZERO_HASHES_17 ==Int  63799769208876827738003032821893022143097474293424873737753651534389224801195
+    andBool ZERO_HASHES_18 ==Int  67816509212607392382740074792956495608635882665724233434230291854030732195236
+    andBool ZERO_HASHES_19 ==Int 112434921305070287559384313443636314384702132445424344431569901673819370811775
+    andBool ZERO_HASHES_20 ==Int  93112230953615344385943808306254931967020084209711158834711445534019305401258
+    andBool ZERO_HASHES_21 ==Int  62669181200805966564192421757819261985029837393920877947563891644048741760924
+    andBool ZERO_HASHES_22 ==Int 115205076510789746548603599597779790746302978279183356048242913992201050263911
+    andBool ZERO_HASHES_23 ==Int 104539113834876204786309677268196632426672930326563741131169818132455910346967
+    andBool ZERO_HASHES_24 ==Int  22220639310854829338009213075933187018531271127936675242871245915956321995712
+    andBool ZERO_HASHES_25 ==Int  15020270542076658589520891983882988038238976963402869888887748183344883676484
+    andBool ZERO_HASHES_26 ==Int  44153847389689082926726920587762841378344527039658864594464812861203077687141
+    andBool ZERO_HASHES_27 ==Int  56477553013929602061607210630309819251225478284985718139011950762099695862212
+    andBool ZERO_HASHES_28 ==Int  59947690453143216863404114195220773987146401062580150977299285593826340359137
+    andBool ZERO_HASHES_29 ==Int  61701827484336113174235061579227602710411934053193562355142130200675961312822
+    andBool ZERO_HASHES_30 ==Int  82317687062382453000908156613654683080667757725396933779730835823850574461532
+    andBool ZERO_HASHES_31 ==Int  68918648562210843738065282119278105929739692988049575047112145589597483221239
+    // cross-check
+    andBool ZERO_HASHES_01 ==Int #sha256(#buf(32,              0) ++ #buf(32,              0))
+    andBool ZERO_HASHES_02 ==Int #sha256(#buf(32, ZERO_HASHES_01) ++ #buf(32, ZERO_HASHES_01))
+    andBool ZERO_HASHES_03 ==Int #sha256(#buf(32, ZERO_HASHES_02) ++ #buf(32, ZERO_HASHES_02))
+    andBool ZERO_HASHES_04 ==Int #sha256(#buf(32, ZERO_HASHES_03) ++ #buf(32, ZERO_HASHES_03))
+    andBool ZERO_HASHES_05 ==Int #sha256(#buf(32, ZERO_HASHES_04) ++ #buf(32, ZERO_HASHES_04))
+    andBool ZERO_HASHES_06 ==Int #sha256(#buf(32, ZERO_HASHES_05) ++ #buf(32, ZERO_HASHES_05))
+    andBool ZERO_HASHES_07 ==Int #sha256(#buf(32, ZERO_HASHES_06) ++ #buf(32, ZERO_HASHES_06))
+    andBool ZERO_HASHES_08 ==Int #sha256(#buf(32, ZERO_HASHES_07) ++ #buf(32, ZERO_HASHES_07))
+    andBool ZERO_HASHES_09 ==Int #sha256(#buf(32, ZERO_HASHES_08) ++ #buf(32, ZERO_HASHES_08))
+    andBool ZERO_HASHES_10 ==Int #sha256(#buf(32, ZERO_HASHES_09) ++ #buf(32, ZERO_HASHES_09))
+    andBool ZERO_HASHES_11 ==Int #sha256(#buf(32, ZERO_HASHES_10) ++ #buf(32, ZERO_HASHES_10))
+    andBool ZERO_HASHES_12 ==Int #sha256(#buf(32, ZERO_HASHES_11) ++ #buf(32, ZERO_HASHES_11))
+    andBool ZERO_HASHES_13 ==Int #sha256(#buf(32, ZERO_HASHES_12) ++ #buf(32, ZERO_HASHES_12))
+    andBool ZERO_HASHES_14 ==Int #sha256(#buf(32, ZERO_HASHES_13) ++ #buf(32, ZERO_HASHES_13))
+    andBool ZERO_HASHES_15 ==Int #sha256(#buf(32, ZERO_HASHES_14) ++ #buf(32, ZERO_HASHES_14))
+    andBool ZERO_HASHES_16 ==Int #sha256(#buf(32, ZERO_HASHES_15) ++ #buf(32, ZERO_HASHES_15))
+    andBool ZERO_HASHES_17 ==Int #sha256(#buf(32, ZERO_HASHES_16) ++ #buf(32, ZERO_HASHES_16))
+    andBool ZERO_HASHES_18 ==Int #sha256(#buf(32, ZERO_HASHES_17) ++ #buf(32, ZERO_HASHES_17))
+    andBool ZERO_HASHES_19 ==Int #sha256(#buf(32, ZERO_HASHES_18) ++ #buf(32, ZERO_HASHES_18))
+    andBool ZERO_HASHES_20 ==Int #sha256(#buf(32, ZERO_HASHES_19) ++ #buf(32, ZERO_HASHES_19))
+    andBool ZERO_HASHES_21 ==Int #sha256(#buf(32, ZERO_HASHES_20) ++ #buf(32, ZERO_HASHES_20))
+    andBool ZERO_HASHES_22 ==Int #sha256(#buf(32, ZERO_HASHES_21) ++ #buf(32, ZERO_HASHES_21))
+    andBool ZERO_HASHES_23 ==Int #sha256(#buf(32, ZERO_HASHES_22) ++ #buf(32, ZERO_HASHES_22))
+    andBool ZERO_HASHES_24 ==Int #sha256(#buf(32, ZERO_HASHES_23) ++ #buf(32, ZERO_HASHES_23))
+    andBool ZERO_HASHES_25 ==Int #sha256(#buf(32, ZERO_HASHES_24) ++ #buf(32, ZERO_HASHES_24))
+    andBool ZERO_HASHES_26 ==Int #sha256(#buf(32, ZERO_HASHES_25) ++ #buf(32, ZERO_HASHES_25))
+    andBool ZERO_HASHES_27 ==Int #sha256(#buf(32, ZERO_HASHES_26) ++ #buf(32, ZERO_HASHES_26))
+    andBool ZERO_HASHES_28 ==Int #sha256(#buf(32, ZERO_HASHES_27) ++ #buf(32, ZERO_HASHES_27))
+    andBool ZERO_HASHES_29 ==Int #sha256(#buf(32, ZERO_HASHES_28) ++ #buf(32, ZERO_HASHES_28))
+    andBool ZERO_HASHES_30 ==Int #sha256(#buf(32, ZERO_HASHES_29) ++ #buf(32, ZERO_HASHES_29))
+    andBool ZERO_HASHES_31 ==Int #sha256(#buf(32, ZERO_HASHES_30) ++ #buf(32, ZERO_HASHES_30))
+refund: _ => _
 +requires:
     // conditions
     andBool CALL_VALUE ==Int 0
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 352, .Set)
-GAS_COST: 85
+memory_used: #symMem(0 => 4278, .Set)
+GAS_COST: 672893
 
-[init-loop0]
-pc: {PC_LOOPENTER} => {PC_LOOPHEAD}
-word_stack: {WORD_STACK_INIT} => 1 : {WORD_STACK_INIT}
-local_mem: {LOCAL_MEM_INIT} => {LOCAL_MEM_INIT}
-    [ 192 /* scratchpad     */ := #buf(32, 2) ]                  /* zero_hashes storage index = 2 */
-    [ 384 /* = 320 + 32 * 2 */ := #buf(32, select(.Map, #hashedLocation({COMPILER}, {ZERO_HASHES}, 0))) ]    /* self.zero_hashes[0] */
-    [ 416 /* = 320 + 32 * 3 */ := #buf(32, select(.Map, #hashedLocation({COMPILER}, {ZERO_HASHES}, 0))) ]    /* self.zero_hashes[0] */
-    [ 352 /* = 320 + 32 * 1 */ := #buf(32, 64) ]                 /* size of sha256 */
-    [ 192 /* scratchpad     */ := #buf(32, {ZERO_HASHES_1}) ]    /* sha256(384, 64) return */
-    [ 192 /* scratchpad     */ := #buf(32, 2) ]                  /* zero_hashes storage index = 2 */
-    [ 320 /* = 320 + 32 * 0 */ := #buf(32, 1) ]                  /* i = 1 */
-storage: .Map => .Map
-    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, 1) <- {ZERO_HASHES_1} ]
-refund: _ => _
-ZERO_HASHES_1: #sha256(#buf(32, 0) ++ #buf(32, 0))
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(352 => 448, .Set)
-GAS_COST: 21667
-
-[init-loop]
-LOCAL_MEM_LOOPHEAD: {LOCAL_MEM_INIT}
-    [ 192 /* scratchpad     */ := #buf(32, 2) ]              /* zero_hashes storage index = 2 */
-    [ 384 /* = 320 + 32 * 2 */ := #buf(32, ANON_1) ]         /* self.zero_hashes[i] */
-    [ 416 /* = 320 + 32 * 3 */ := #buf(32, ANON_2) ]         /* self.zero_hashes[i] */
-    [ 352 /* = 320 + 32 * 1 */ := #buf(32, 64) ]             /* size of sha256 */
-    [ 320 /* = 320 + 32 * 0 */ := #buf(32, I) ]              /* i = i + 1 */
-storage: M
-+requires:
-    // conditions
-    andBool #range(0 <= I <= 31)
-    // types
-    andBool isStorage(M)
-    andBool #rangeUInt(256, ANON_1)
-    andBool #rangeUInt(256, ANON_2)
-
-[init-loop-enter]
-pc: {PC_LOOPHEAD}
-word_stack: (I => I +Int 1) : {WORD_STACK_INIT}
-local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
-    [ 192 /* scratchpad     */ := #buf(32, 2) ]                  /* zero_hashes storage index = 2 */
-    [ 384 /* = 320 + 32 * 2 */ := #buf(32, select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, I))) ]  /* self.zero_hashes[i] */
-    [ 416 /* = 320 + 32 * 3 */ := #buf(32, select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, I))) ]  /* self.zero_hashes[i] */
-    [ 352 /* = 320 + 32 * 1 */ := #buf(32, 64) ]                 /* size of sha256 */
-    [ 192 /* scratchpad     */ := #buf(32, {ZERO_HASHES_I+1}) ]  /* sha256(384, 64) return */
-    [ 192 /* scratchpad     */ := #buf(32, 2) ]                  /* zero_hashes storage index = 2 */
-    [ 320 /* = 320 + 32 * 0 */ := #buf(32, I +Int 1) ]           /* i = i + 1 */
-storage: M => M
-    [ #hashedLocation({COMPILER}, {ZERO_HASHES}, I +Int 1) <- {ZERO_HASHES_I+1} ]
-refund: _ => _
-ZERO_HASHES_I: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, I))
-ZERO_HASHES_I+1: #sha256(#buf(32, {ZERO_HASHES_I}) ++ #buf(32, {ZERO_HASHES_I}))
-+requires:
-    // conditions
-    andBool I <Int 31
-gas:         #symGas(G, 0 => 6689, 0 => 21689, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(448, .Set)
-
-[init-loop-exit]
+[init-revert]
 k: #execute => #halt
-status_code: _ => EVMC_SUCCESS
-pc: {PC_LOOPHEAD} => {PC_END}
-output: _ => #parseByteStack({RUNTIME_CODE})
-word_stack: I : {WORD_STACK_INIT} => .WordStack
-local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
-    [ 0 := #parseByteStack({RUNTIME_CODE}) ]
+status_code: _ => EVMC_REVERT
+pc: 0 => 151
 +requires:
     // conditions
-    andBool I ==Int 31
+    andBool CALL_VALUE =/=Int 0
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(448 => 4278, .Set)
-GAS_COST: 471
+memory_used: #symMem(0 => 192, .Set)
+GAS_COST: 69
 
 ;
 ; to_little_endian_64
@@ -1363,15 +1391,6 @@ MEM_COST: 192
 +requires:
     // conditions
     andBool CALL_DATA_SIZE >=Int 32
-
-[revert-init]
-code: {INIT_CODE}
-pc: 0 => 151
-+requires:
-    // conditions
-    andBool CALL_VALUE =/=Int 0
-gas:         #symGas(G, 0 => 69, 0 => 69, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 192, .Set)
 
 [revert-get_deposit_root]
 call_data: #abiCallData("get_deposit_root", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -598,7 +598,15 @@ GAS_COST: 11385
 ; The term `#buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)` models certain extra call-data added accidently or intentionally.
 ; This ensures that the function works correctly even in such a case.
 call_data: #abiCallData("get_deposit_count", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)
-storage: M
+
+[get_deposit_count-success]
+k: #execute => #halt
+status_code: _ => EVMC_SUCCESS
+pc: 0 => 1561
+output: _ => #encodeArgs(#bytes(#bufSeg(#buf(32, Y8), 24, 8))) /* #buf(32, 32) ++ #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0) */
+storage: M  /* constant function; no storage update */
+word_stack: .WordStack
+local_mem: .Map => _
 +requires:
     // conditions
     andBool CALL_VALUE ==Int 0
@@ -608,59 +616,20 @@ storage: M
     // let-bindings
     andBool DEPOSIT_COUNT ==Int select(M, #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList))
     {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
-LOCAL_MEM_BEGIN: .Map
-    ; function hash
-    [  28 := 98 : 31 : 209 : 48 : #take(28, #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)) ]
-    {VYPER_GENERATED_BOUNDS}
-k: #execute => #halt
-status_code: _ => EVMC_SUCCESS
-pc: 0 => 1561
-output: _ => #encodeArgs(#bytes(#bufSeg(#buf(32, Y8), 24, 8)))
-; output: _ => #buf(32, 32) ++ #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0)
-;            ; 608             640            672                             680         704
-word_stack: .WordStack
-local_mem: .Map => {LOCAL_MEM_BEGIN}
-    ; before call
-    [ 320 /* = 320 + 32 *  0      */ := #buf(32, 2154246793) ]     /* 0x80673289 */ /* ??? */
-    [ 352 /* = 320 + 32 *  1      */ := #buf(32, DEPOSIT_COUNT) ]
-    ; call to_little_endian_64
-    {LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
-    ; after call
-    [ 448 /* = 320 + 32 *  4      */ := #buf(32, 8) ]
-    [ 544 /* = 320 + 32 *  7      */ := #buf(32, 0) ]
-    [ 480 /* = 320 + 32 *  5      */ := #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0) ]  /* return value from to_little_endian_64 */
-    [ 544 /* = 320 + 32 *  7      */ := #buf(32, 32) ]
-    [ 640 /* = 320 + 32 * 10      */ := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ]  /* memcpy(640 <- 448, 40) */
-    [ 736 /* = 320 + 32 * 13      */ := #buf(32, 32) ]                                 /* zero padding loop index */
-    [ 680 /* = 320 + 32 * 11 +  8 */ <- 0 ]                                            /* zero padding */
-    [ 681 /* = 320 + 32 * 11 +  9 */ <- 0 ]
-    [ 682 /* = 320 + 32 * 11 + 10 */ <- 0 ]
-    [ 683 /* = 320 + 32 * 11 + 11 */ <- 0 ]
-    [ 684 /* = 320 + 32 * 11 + 12 */ <- 0 ]
-    [ 685 /* = 320 + 32 * 11 + 13 */ <- 0 ]
-    [ 686 /* = 320 + 32 * 11 + 14 */ <- 0 ]
-    [ 687 /* = 320 + 32 * 11 + 15 */ <- 0 ]
-    [ 688 /* = 320 + 32 * 11 + 16 */ <- 0 ]
-    [ 689 /* = 320 + 32 * 11 + 17 */ <- 0 ]
-    [ 690 /* = 320 + 32 * 11 + 18 */ <- 0 ]
-    [ 691 /* = 320 + 32 * 11 + 19 */ <- 0 ]
-    [ 692 /* = 320 + 32 * 11 + 20 */ <- 0 ]
-    [ 693 /* = 320 + 32 * 11 + 21 */ <- 0 ]
-    [ 694 /* = 320 + 32 * 11 + 22 */ <- 0 ]
-    [ 695 /* = 320 + 32 * 11 + 23 */ <- 0 ]
-    [ 696 /* = 320 + 32 * 11 + 24 */ <- 0 ]
-    [ 697 /* = 320 + 32 * 11 + 25 */ <- 0 ]
-    [ 698 /* = 320 + 32 * 11 + 26 */ <- 0 ]
-    [ 699 /* = 320 + 32 * 11 + 27 */ <- 0 ]
-    [ 700 /* = 320 + 32 * 11 + 28 */ <- 0 ]
-    [ 701 /* = 320 + 32 * 11 + 29 */ <- 0 ]
-    [ 702 /* = 320 + 32 * 11 + 30 */ <- 0 ]
-    [ 703 /* = 320 + 32 * 11 + 31 */ <- 0 ]
-    [ 608 /* = 320 + 32 *  9      */ := #buf(32, 32) ]                                 /* return(608, 96) */
-RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64: 1348
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem(0 => 832, .Set)
 GAS_COST: 11424
+
+[get_deposit_count-revert]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+pc: 0 => 1318
++requires:
+    // conditions
+    andBool CALL_VALUE =/=Int 0
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => 192, .Set)
+GAS_COST: 183
 
 ;
 ; deposit
@@ -1401,16 +1370,6 @@ pc: 0 => 663
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem(0 => 192, .Set)
 GAS_COST: 154
-
-[revert-get_deposit_count]
-call_data: #abiCallData("get_deposit_count", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)
-pc: 0 => 1318
-+requires:
-    // conditions
-    andBool CALL_VALUE =/=Int 0
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 192, .Set)
-GAS_COST: 183
 
 ;
 ; globals


### PR DESCRIPTION
Now the `init` spec becomes straightforward, specifying only two cases: success and failure. The success case spec describes the entire function execution, specifying only the status code, the output, the storage update, and the gas cost.

More spec improvement will come, and the original full spec is moved to `deposit-spec-full.ini` for a backup and a future reference.