### PR TITLE
Deposit: simplify get_deposit_root spec

### DIFF
--- a/deposit/bytecode-verification/Makefile
+++ b/deposit/bytecode-verification/Makefile
@@ -15,12 +15,12 @@ KPROVE_OPTS:=--smt-prelude $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)
 SPEC_NAMES:=init-success \
             init-revert \
             to_little_endian_64 \
-            get_deposit_root-init \
-            get_deposit_root-loop0-then \
-            get_deposit_root-loop0-else \
-            get_deposit_root-loop-body-then \
-            get_deposit_root-loop-body-else \
-            get_deposit_root-loop-exit \
+            get_deposit_root-success-loop1-then \
+            get_deposit_root-success-loop1-else \
+            get_deposit_root-success-loop-body-then \
+            get_deposit_root-success-loop-body-else \
+            get_deposit_root-success-loop-exit \
+            get_deposit_root-revert \
             get_deposit_count-success \
             get_deposit_count-revert \
             deposit-init \
@@ -45,15 +45,11 @@ SPEC_NAMES:=init-success \
             deposit-data-revert \
             revert-invalid_function_identifier-lt_4 \
             revert-invalid_function_identifier-ge_4-lt_32 \
-            revert-invalid_function_identifier-ge_4-ge_32 \
-            revert-get_deposit_root
+            revert-invalid_function_identifier-ge_4-ge_32
 
 include ../../resources/kprove.mak
 
 # non-standard spec generation
-
-$(SPECS_DIR)/$(SPEC_GROUP)/get_deposit_root-loop-exit-spec.k: $(TMPLS) $(SPEC_INI) $(LEMMAS)
-	python3 $(RESOURCES)/gen-spec.py $(TMPLS) $(SPEC_INI) get_deposit_root-loop-exit to_little_endian_64-trusted get_deposit_root-loop-exit > $@
 
 $(SPECS_DIR)/$(SPEC_GROUP)/deposit-subcall_1-spec.k: $(TMPLS) $(SPEC_INI) $(LEMMAS)
 	python3 $(RESOURCES)/gen-spec.py $(TMPLS) $(SPEC_INI) deposit-subcall_1            to_little_endian_64-trusted deposit-subcall_1            > $@

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -53,6 +53,12 @@ VYPER_GENERATED_BOUNDS:
     [  96 := #buf(32, 115792089237316195423570985008687907853099843482180094807725896704197245534208) ]
     [ 128 := #buf(32, 1701411834604692317316873037158841057270000000000) ]
     [ 160 := #buf(32, 115792089237316195423570985006986496018665292348323691002298742950633129639936) ]
+ENSURES_VYPER_GENERATED_BOUNDS:
+    andBool #range(NEW_MEM,  32, 32) ==K #buf(32, 1461501637330902918203684832716283019655932542976)
+    andBool #range(NEW_MEM,  64, 32) ==K #buf(32, 170141183460469231731687303715884105727)
+    andBool #range(NEW_MEM,  96, 32) ==K #buf(32, 115792089237316195423570985008687907853099843482180094807725896704197245534208)
+    andBool #range(NEW_MEM, 128, 32) ==K #buf(32, 1701411834604692317316873037158841057270000000000)
+    andBool #range(NEW_MEM, 160, 32) ==K #buf(32, 115792089237316195423570985006986496018665292348323691002298742950633129639936)
 LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT:
     [ 352 /* = 320 + 32 *  1      */ := #buf(32, {RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64}) ]  /* return address */
     [ 320 /* = 320 + 32 *  0      */ := #buf(32, DEPOSIT_COUNT) ]  /* argument */
@@ -398,6 +404,8 @@ memory_used: #symMem(0, .Set) => _
 ; The term `#buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)` models certain extra call-data added accidently or intentionally.
 ; This ensures that the function works correctly even in such a case.
 call_data: #abiCallData("get_deposit_root", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)
+
+[get_deposit_root-success]
 storage: M
 +requires:
     // conditions
@@ -407,181 +415,98 @@ storage: M
     andBool isStorage(M)
     // let-bindings
     andBool DEPOSIT_COUNT ==Int select(M, #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList))
-PC_LOOPENTER: 697
 PC_LOOPHEAD: 968
 PC_END: 1291
-WORD_STACK_INIT: 32 : 416 : .WordStack
-LOCAL_MEM_BEGIN: .Map
-    ; function hash
-    [  28 := 197 : 242 : 137 : 47 : #take(28, #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)) ]
-    {VYPER_GENERATED_BOUNDS}
-LOCAL_MEM_INIT: {LOCAL_MEM_BEGIN}
-    ; locals
-    [ 320 /* = 320 + 32 * 0 */ := #buf(32, 0) ]              /* zero_bytes32: bytes32 = 0x0 */
-    [ 352 /* = 320 + 32 * 1 */ := #buf(32, 0) ]              /* node: bytes32 = zero_bytes32 */
-    [ 384 /* = 320 + 32 * 2 */ := #buf(32, DEPOSIT_COUNT) ]  /* size: uint256 = self.deposit_count */
-    [ 416 /* = 320 + 32 * 3 */ := #buf(32, 0) ]              /* height = 0 */
+WORD_STACK_LOOP: {LOOP_BOUND} : {LOOP_INDEX_ADDR} : .WordStack
+LOOP_BOUND: 32
+LOOP_INDEX_ADDR: 416
 
-[get_deposit_root-init]
-pc: 0 => {PC_LOOPENTER}
-word_stack: .WordStack => {WORD_STACK_INIT}
-local_mem: .Map => {LOCAL_MEM_INIT}
-; gas usage = 417 = 375 + ( 42 = 3*n + n^2 / 512 where n = 14 = 448 / 32 )
+[get_deposit_root-success-loop1]
+pc: 0 => {PC_LOOPHEAD}
+word_stack: .WordStack => 1 : {WORD_STACK_LOOP}
+local_mem: .Map => NEW_MEM
++ensures:
+    {ENSURES_VYPER_GENERATED_BOUNDS}
+    andBool #range(NEW_MEM, 320, 32) ==K #buf(32, 0)
+    andBool #range(NEW_MEM, 352, 32) ==K #buf(32, {NODE_1})
+    andBool #range(NEW_MEM, 384, 32) ==K #buf(32, DEPOSIT_COUNT /Int 2)
+    andBool #range(NEW_MEM, 416, 32) ==K #buf(32, 1)
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 448, .Set)
-GAS_COST: 400
+memory_used: #symMem(0 => {MEM_COST}, .Set)
 
-[get_deposit_root-loop0]
-pc: {PC_LOOPENTER} => {PC_LOOPHEAD}
-word_stack: {WORD_STACK_INIT} => 1 : {WORD_STACK_INIT}
-
-[get_deposit_root-loop0-then]
-local_mem: {LOCAL_MEM_INIT} => {LOCAL_MEM_INIT}
-    [ 192 /* scratchpad      */ := #buf(32, 0) ]                              /* branch storage index = 0 */
-    [ 608 /* = 320 + 32 *  9 */ := #buf(32, {BRANCH_0}) ]                     /* branch[0] */
-    [ 640 /* = 320 + 32 * 10 */ := #buf(32, 0) ]                              /* node */
-    [ 576 /* = 320 + 32 *  8 */ := #buf(32, 64) ]                             /* size of sha256 input */
-    [ 192 /* scratchpad      */ := #buf(32, {NODE_1}) ]                       /* sha256 return value via sha256(608, 64) */
-    [ 352 /* = 320 + 32 *  1 */ := #buf(32, {NODE_1}) ]                       /* update node = sha256(branch[0], node) */
-    [ 384 /* = 320 + 32 *  2 */ := #buf(32, DEPOSIT_COUNT /Int 2) ]           /* update size */
-    [ 416 /* = 320 + 32 *  3 */ := #buf(32, 1) ]                              /* update height */
-BRANCH_0: select(M, #hashedLocation({COMPILER}, {BRANCH}, 0))
+[get_deposit_root-success-loop1-then]
 NODE_1: #sha256(#buf(32, {BRANCH_0}) ++ #buf(32, 0))
+BRANCH_0: select(M, #hashedLocation({COMPILER}, {BRANCH}, 0))
 +requires:
     // conditions
     andBool DEPOSIT_COUNT &Int 1 ==Int 1
-; gas usage = 1766 = 1703 + ( 63 = 3*n + n^2 / 512 where n = 21 = 672 / 32 )
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(448 => 672, .Set)
-GAS_COST: 1328
+GAS_COST: 1728
+MEM_COST: 672
 
-[get_deposit_root-loop0-else]
-local_mem: {LOCAL_MEM_INIT} => {LOCAL_MEM_INIT}
-    [ 480 /* = 320 + 32 *  5 */ := #buf(32, 0) ]                              /* node */
-    [ 192 /* scratchpad      */ := #buf(32, 2) ]                              /* zero_hashes storage index = 2 */
-    [ 512 /* = 320 + 32 *  6 */ := #buf(32, {ZERO_HASHES_0}) ]                /* zero_hashes[0] */
-    [ 448 /* = 320 + 32 *  4 */ := #buf(32, 64) ]                             /* size of sha256 input */
-    [ 192 /* scratchpad      */ := #buf(32, {NODE_1}) ]                       /* sha256 return value via sha256(480, 64) */
-    [ 352 /* = 320 + 32 *  1 */ := #buf(32, {NODE_1}) ]                       /* update node = sha256(node, zero_hashes[0]) */
-    [ 384 /* = 320 + 32 *  2 */ := #buf(32, DEPOSIT_COUNT /Int 2) ]           /* update size */
-    [ 416 /* = 320 + 32 *  3 */ := #buf(32, 1) ]                              /* update height */
-ZERO_HASHES_0: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, 0))
+[get_deposit_root-success-loop1-else]
 NODE_1: #sha256(#buf(32, 0) ++ #buf(32, {ZERO_HASHES_0}))
+ZERO_HASHES_0: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, 0))
 +requires:
     // conditions
     andBool DEPOSIT_COUNT &Int 1 =/=Int 1
-; gas usage = 1744 = 1693 + ( 51 = 3*n + n^2 / 512 where n = 17 = 544 / 32 )
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(448 => 544, .Set)
-GAS_COST: 1318
+GAS_COST: 1718
+MEM_COST: 544
 
-[get_deposit_root-loop]
-; MEMORY_USED_LOOPHEAD: 17 or 21
-LOCAL_MEM_LOOPHEAD: {LOCAL_MEM_BEGIN}
+[get_deposit_root-success-loop]
+LOCAL_MEM_LOOPHEAD: MEM
+    {VYPER_GENERATED_BOUNDS}
     ; locals
-    [ 320 /* = 320 + 32 *  0 */ := #buf(32, 0) ]          /* zero_bytes32: bytes32 = 0x0 */
-    [ 352 /* = 320 + 32 *  1 */ := #buf(32, NODE) ]       /* node: bytes32 */
-    [ 384 /* = 320 + 32 *  2 */ := #buf(32, SIZE) ]       /* size: uint256 */
-    [ 416 /* = 320 + 32 *  3 */ := #buf(32, HEIGHT) ]     /* height */
-    ; garbages
-    [ 192 /* scratchpad      */ := #buf(32, ANON_1) ]     /* sha256 return value */
-    // for if-then branch
-    [ 576 /* = 320 + 32 *  8 */ := #buf(32, ANON_2) ]     /* size of sha256 input */
-    [ 608 /* = 320 + 32 *  9 */ := #buf(32, ANON_3) ]     /* branch[height] */
-    [ 640 /* = 320 + 32 * 10 */ := #buf(32, ANON_4) ]     /* node */
-    // for if-else branch
-    [ 448 /* = 320 + 32 *  4 */ := #buf(32, ANON_5) ]     /* size of sha256 input */
-    [ 480 /* = 320 + 32 *  5 */ := #buf(32, ANON_6) ]     /* node */
-    [ 512 /* = 320 + 32 *  6 */ := #buf(32, ANON_7) ]     /* zero_hashes[height] */
+    [ 320 /* = 320 + 32 * 0 */ := #buf(32, 0) ]          /* zero_bytes32: bytes32 = 0x0 */
+    [ 352 /* = 320 + 32 * 1 */ := #buf(32, NODE) ]       /* node: bytes32 */
+    [ 384 /* = 320 + 32 * 2 */ := #buf(32, SIZE) ]       /* size: uint256 */
+    [ 416 /* = 320 + 32 * 3 */ := #buf(32, HEIGHT) ]     /* height */
 +requires:
     // conditions
     andBool #range(0 <= HEIGHT <= 32)
     // types
     andBool #rangeUInt(256, NODE)
     andBool #rangeUInt(256, SIZE)
-    andBool #rangeUInt(256, ANON_1)
-    andBool #rangeUInt(256, ANON_2)
-    andBool #rangeUInt(256, ANON_3)
-    andBool #rangeUInt(256, ANON_4)
-    andBool #rangeUInt(256, ANON_5)
-    andBool #rangeUInt(256, ANON_6)
-    andBool #rangeUInt(256, ANON_7)
 
-[get_deposit_root-loop-body]
+[get_deposit_root-success-loop-body]
 pc: {PC_LOOPHEAD}
-word_stack: (HEIGHT => HEIGHT +Int 1) : {WORD_STACK_INIT}
+word_stack: (HEIGHT => HEIGHT +Int 1) : {WORD_STACK_LOOP}
+local_mem: {LOCAL_MEM_LOOPHEAD} => NEW_MEM
++ensures:
+    {ENSURES_VYPER_GENERATED_BOUNDS}
+    andBool #range(NEW_MEM, 320, 32) ==K #buf(32, 0)
+    andBool #range(NEW_MEM, 352, 32) ==K #buf(32, {NODE_NEW})
+    andBool #range(NEW_MEM, 384, 32) ==K #buf(32, SIZE /Int 2)
+    andBool #range(NEW_MEM, 416, 32) ==K #buf(32, HEIGHT +Int 1)
 +requires:
     // conditions
     andBool HEIGHT <Int 32
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(672, .Set)
 
-[get_deposit_root-loop-body-then]
-local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
-    [ 192 /* scratchpad      */ := #buf(32, 0) ]                      /* branch storage index = 0 */
-    [ 608 /* = 320 + 32 *  9 */ := #buf(32, {BRANCH_HEIGHT}) ]        /* branch[height] */
-    [ 640 /* = 320 + 32 * 10 */ := #buf(32, NODE) ]                   /* node */
-    [ 576 /* = 320 + 32 *  8 */ := #buf(32, 64) ]                     /* size of sha256 input */
-    [ 192 /* scratchpad      */ := #buf(32, {NODE_NEW}) ]             /* sha256 return value */
-    [ 352 /* = 320 + 32 *  1 */ := #buf(32, {NODE_NEW}) ]             /* update node */
-    [ 384 /* = 320 + 32 *  2 */ := #buf(32, SIZE /Int 2) ]            /* update size */
-    [ 416 /* = 320 + 32 *  3 */ := #buf(32, HEIGHT +Int 1) ]          /* update height */
-BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
+[get_deposit_root-success-loop-body-then]
 NODE_NEW: #sha256(#buf(32, {BRANCH_HEIGHT}) ++ #buf(32, NODE))
+BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
 +requires:
     // conditions
     andBool SIZE &Int 1 ==Int 1
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(672, .Set)
 GAS_COST: 1350
 
-[get_deposit_root-loop-body-else]
-local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
-    [ 480 /* = 320 + 32 *  5 */ := #buf(32, NODE) ]                   /* node */
-    [ 192 /* scratchpad      */ := #buf(32, 2) ]                      /* zero_hashes storage index = 2 */
-    [ 512 /* = 320 + 32 *  6 */ := #buf(32, {ZERO_HASHES_HEIGHT}) ]   /* zero_hashes[height] */
-    [ 448 /* = 320 + 32 *  4 */ := #buf(32, 64) ]                     /* size of sha256 input */
-    [ 192 /* scratchpad      */ := #buf(32, {NODE_NEW}) ]             /* sha256 return value via sha256(480, 64) */
-    [ 352 /* = 320 + 32 *  1 */ := #buf(32, {NODE_NEW}) ]             /* update node = sha256(node, zero_hashes[height]) */
-    [ 384 /* = 320 + 32 *  2 */ := #buf(32, SIZE /Int 2) ]            /* update size = size / 2 */
-    [ 416 /* = 320 + 32 *  3 */ := #buf(32, HEIGHT +Int 1) ]          /* update height = height + 1 */
-ZERO_HASHES_HEIGHT: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, HEIGHT))
+[get_deposit_root-success-loop-body-else]
 NODE_NEW: #sha256(#buf(32, NODE) ++ #buf(32, {ZERO_HASHES_HEIGHT}))
+ZERO_HASHES_HEIGHT: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, HEIGHT))
 +requires:
     // conditions
     andBool SIZE &Int 1 =/=Int 1
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(672, .Set)
 GAS_COST: 1340
 
-[get_deposit_root-loop-exit]
+[get_deposit_root-success-loop-exit]
 k: #execute => #halt
 status_code: _ => EVMC_SUCCESS
 pc: {PC_LOOPHEAD} => {PC_END}
 RETURN_VAL: #sha256(#buf(32, NODE) ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0))
 output: _ => #buf(32, {RETURN_VAL})
-word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
-local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
-    ; preparing for calling to_little_endian_64
-    [ 1152 /* = 1120 + 32 *  1     */ := #buf(32, NODE) ]
-    [  736 /* =  320 + 32 * 13     */ := #buf(32, 2154246793) ]            /* 0x80673289 */ /* ??? */
-    [  768 /* =  320 + 32 * 14     */ := #buf(32, DEPOSIT_COUNT) ]
-    ; call to_little_endian_64 (pc: 1013 -> [155 -> ... -> 628] -> 1014)
-    {LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
-    ; finish
-    [  864 /* =  320 + 32 * 17     */ := #buf(32, 8) ]
-    [  960 /* =  320 + 32 * 20     */ := #buf(32, 0) ]
-    [  896 /* =  320 + 32 * 18     */ := #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0) ]
-    [  960 /* =  320 + 32 * 20     */ := #buf(32, 32) ]
-    [  384 /* =  320 + 32 *  2     */ := #buf(32, SIZE) ]                  /* restore size: uint256 */
-    [  352 /* =  320 + 32 *  1     */ := #buf(32, NODE) ]                  /* restore node: bytes32 */
-    [  320 /* =  320 + 32 *  0     */ := #buf(32, 0) ]                     /* restore zero_bytes32: bytes32 */
-    [ 1184 /* = 1120 + 32 *  2     */ := #bufSeg(#buf(32, Y8), 24, 8) ]    /* self.to_little_endian_64(self.deposit_count) */  /* via memcpy(1152 <- 864,  8) */
-    [ 1024 /* =  320 + 32 * 22     */ := #buf(32, 0) ]                     /* zero_bytes32 */                                  /* via memcpy( 992 <- 320, 32) */
-    [  992 /* =  320 + 32 * 21     */ := #buf(32, 24) ]                    /* slice len */
-    [ 1192 /* = 1120 + 32 *  2 + 8 */ := #buf(24, 0) ]                     /* slice(zero_bytes32, start=0, len=24) */          /* via memcpy(1160 <- 992, 24) */
-    [ 1120 /* = 1120 + 32 *  0     */ := #buf(32, 64) ]
-    [  192 /* scratchpad           */ := #buf(32, {RETURN_VAL}) ]          /* via sha256(1120, 64) */
-    [    0                            := #buf(32, {RETURN_VAL}) ]          /* return sha256(concat(node, self.to_little_endian_64(self.deposit_count), slice(zero_bytes32, start=0, len=24))) */
-RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64: 1039
+word_stack: HEIGHT : {WORD_STACK_LOOP} => .WordStack
+local_mem: {LOCAL_MEM_LOOPHEAD} => _
 +requires:
     // conditions
     andBool HEIGHT ==Int 32
@@ -589,6 +514,17 @@ RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64: 1039
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem(672 => 1216, .Set)
 GAS_COST: 11385
+
+[get_deposit_root-revert]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+pc: 0 => 663
++requires:
+    // conditions
+    andBool CALL_VALUE =/=Int 0
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => 192, .Set)
+GAS_COST: 154
 
 ;
 ; get_deposit_count
@@ -1360,16 +1296,6 @@ MEM_COST: 192
 +requires:
     // conditions
     andBool CALL_DATA_SIZE >=Int 32
-
-[revert-get_deposit_root]
-call_data: #abiCallData("get_deposit_root", .TypedArgs) ++ #buf(EXTRA_CALL_DATA_SIZE, EXTRA_CALL_DATA)
-pc: 0 => 663
-+requires:
-    // conditions
-    andBool CALL_VALUE =/=Int 0
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 192, .Set)
-GAS_COST: 154
 
 ;
 ; globals


### PR DESCRIPTION
This simplifies the get_deposit_root spec. Only the necessary part (i.e., the local variables) of the local memory update is specified. Unlike the init spec, it is not feasible to explicitly enumerate all paths of the function, because although the loop bound is fixed to 32, it leads to 2^32 paths, due to the if-statement in the loop body. Thus, we adopt the refinement-based approach (described [here](https://github.com/runtimeverification/verified-smart-contracts/wiki/Our-Refinement-Based-Formal-Verification-Approach)) to write a spec recursively.