### PR TITLE
Deposit: simplify deposit spec

### DIFF
--- a/deposit/bytecode-verification/Makefile
+++ b/deposit/bytecode-verification/Makefile
@@ -12,47 +12,44 @@ KPROVE_OPTS:=--smt-prelude $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)
              --branching-allowed 0 \
              --z3-cnstr-timeout 100
 
-SPEC_NAMES:=init-success \
-            init-revert \
-            to_little_endian_64 \
-            get_deposit_root-success-loop1-then \
-            get_deposit_root-success-loop1-else \
-            get_deposit_root-success-loop-body-then \
-            get_deposit_root-success-loop-body-else \
-            get_deposit_root-success-loop-exit \
-            get_deposit_root-revert \
-            get_deposit_count-success \
-            get_deposit_count-revert \
-            deposit-init \
-            deposit-subcall_1 \
-            deposit-subcall_2 \
-            deposit-log \
-            deposit-data \
-            deposit-add-init-then \
-            deposit-add-init-else \
-            deposit-add-loop-enter-then \
-            deposit-add-loop-enter-else \
-            deposit-add-loop-exit \
-            deposit-init-calldata \
-            deposit-init-calldata-revert-1 \
-            deposit-init-calldata-revert-2 \
-            deposit-init-calldata-revert-3 \
-            deposit-init-calldata-revert-4 \
-            deposit-init-calldata-revert-5 \
-            deposit-init-calldata-revert-6 \
-            deposit-init-revert-1 \
-            deposit-init-revert-2 \
-            deposit-data-revert \
-            revert-invalid_function_identifier-lt_4 \
-            revert-invalid_function_identifier-ge_4-lt_32 \
-            revert-invalid_function_identifier-ge_4-ge_32
+SPEC_NAMES:=
+
+SPEC_NAMES += init-success
+SPEC_NAMES += init-revert
+
+SPEC_NAMES += get_deposit_root-success-loop1-then
+SPEC_NAMES += get_deposit_root-success-loop1-else
+SPEC_NAMES += get_deposit_root-success-loop-body-then
+SPEC_NAMES += get_deposit_root-success-loop-body-else
+SPEC_NAMES += get_deposit_root-success-loop-exit
+SPEC_NAMES += get_deposit_root-revert
+
+SPEC_NAMES += get_deposit_count-success
+SPEC_NAMES += get_deposit_count-revert
+
+SPEC_NAMES += deposit-data
+SPEC_NAMES += deposit-revert-1
+SPEC_NAMES += deposit-revert-2
+SPEC_NAMES += deposit-revert-3
+
+SPEC_NAMES += deposit-add-init-then
+SPEC_NAMES += deposit-add-init-else
+SPEC_NAMES += deposit-add-loop-enter-then
+SPEC_NAMES += deposit-add-loop-enter-else
+SPEC_NAMES += deposit-add-loop-exit
+
+SPEC_NAMES += deposit-init-calldata
+SPEC_NAMES += deposit-init-calldata-revert-1
+SPEC_NAMES += deposit-init-calldata-revert-2
+SPEC_NAMES += deposit-init-calldata-revert-3
+SPEC_NAMES += deposit-init-calldata-revert-4
+SPEC_NAMES += deposit-init-calldata-revert-5
+SPEC_NAMES += deposit-init-calldata-revert-6
+
+SPEC_NAMES += revert-invalid_function_identifier-lt_4
+SPEC_NAMES += revert-invalid_function_identifier-ge_4-lt_32
+SPEC_NAMES += revert-invalid_function_identifier-ge_4-ge_32
+
+export K_OPTS=-Xmx16g
 
 include ../../resources/kprove.mak
-
-# non-standard spec generation
-
-$(SPECS_DIR)/$(SPEC_GROUP)/deposit-subcall_1-spec.k: $(TMPLS) $(SPEC_INI) $(LEMMAS)
-	python3 $(RESOURCES)/gen-spec.py $(TMPLS) $(SPEC_INI) deposit-subcall_1            to_little_endian_64-trusted deposit-subcall_1            > $@
-
-$(SPECS_DIR)/$(SPEC_GROUP)/deposit-subcall_2-spec.k: $(TMPLS) $(SPEC_INI) $(LEMMAS)
-	python3 $(RESOURCES)/gen-spec.py $(TMPLS) $(SPEC_INI) deposit-subcall_2            to_little_endian_64-trusted deposit-subcall_2            > $@

--- a/deposit/bytecode-verification/Makefile
+++ b/deposit/bytecode-verification/Makefile
@@ -27,24 +27,24 @@ SPEC_NAMES += get_deposit_root-revert
 SPEC_NAMES += get_deposit_count-success
 SPEC_NAMES += get_deposit_count-revert
 
-SPEC_NAMES += deposit-data
+SPEC_NAMES += deposit-success-data
+SPEC_NAMES += deposit-success-insert-init-then
+SPEC_NAMES += deposit-success-insert-init-else
+SPEC_NAMES += deposit-success-insert-loop-enter-then
+SPEC_NAMES += deposit-success-insert-loop-enter-else
+SPEC_NAMES += deposit-success-insert-loop-exit
+
 SPEC_NAMES += deposit-revert-1
 SPEC_NAMES += deposit-revert-2
 SPEC_NAMES += deposit-revert-3
 
-SPEC_NAMES += deposit-add-init-then
-SPEC_NAMES += deposit-add-init-else
-SPEC_NAMES += deposit-add-loop-enter-then
-SPEC_NAMES += deposit-add-loop-enter-else
-SPEC_NAMES += deposit-add-loop-exit
-
-SPEC_NAMES += deposit-init-calldata
-SPEC_NAMES += deposit-init-calldata-revert-1
-SPEC_NAMES += deposit-init-calldata-revert-2
-SPEC_NAMES += deposit-init-calldata-revert-3
-SPEC_NAMES += deposit-init-calldata-revert-4
-SPEC_NAMES += deposit-init-calldata-revert-5
-SPEC_NAMES += deposit-init-calldata-revert-6
+SPEC_NAMES += deposit-calldata-decoding-success
+SPEC_NAMES += deposit-calldata-decoding-revert-1
+SPEC_NAMES += deposit-calldata-decoding-revert-2
+SPEC_NAMES += deposit-calldata-decoding-revert-3
+SPEC_NAMES += deposit-calldata-decoding-revert-4
+SPEC_NAMES += deposit-calldata-decoding-revert-5
+SPEC_NAMES += deposit-calldata-decoding-revert-6
 
 SPEC_NAMES += revert-invalid_function_identifier-lt_4
 SPEC_NAMES += revert-invalid_function_identifier-ge_4-lt_32

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -428,11 +428,6 @@ storage: M
     andBool DEPOSIT_COUNT ==Int select(M, #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList))
     {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
     {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT}
-    // conditions
-    {CONDITIONS}
-CONDITIONS:
-    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
-    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
 PUBKEY_LENGTH:                 48
 WITHDRAWAL_CREDENTIALS_LENGTH: 32
 SIGNATURE_LENGTH:              96
@@ -476,16 +471,20 @@ MU_ADD_EVEN:     3488
 ;                                                                                                  /       \                        /        \
 ;                                                                                       signature[0:32]  signature[32:64]  signature[64:96]  zero[0:32]
 
-[deposit-data]
+[deposit-success]
++requires:
+    // conditions
+    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
+    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
+    andBool {NODE} ==Int DEPOSIT_DATA_ROOT
+
+[deposit-success-data]
 pc: 0 => {PC_ADD_BEGIN}
 word_stack: .WordStack
 local_mem: .Map => NEW_MEM
 +ensures:
     {ENSURES_VYPER_GENERATED_BOUNDS}
     andBool #range(NEW_MEM, 2784, 32) ==K #buf(32, {NODE})
-+CONDITIONS:
-    // conditions
-    andBool {NODE} ==Int DEPOSIT_DATA_ROOT
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem(0 => {MU_DATA}, .Set)
 GAS_COST: 769 +Int 10925 +Int 12354 +Int 17029 +Int 14366
@@ -495,82 +494,23 @@ log: _:List ( .List => ListItem(#abiEventLog(THIS, "DepositEvent",
             #bytes(#bufSeg(#buf(32, YY8), 24, 8)),
             #bytes(#buf({SIGNATURE_LENGTH}, SIGNATURE)),
             #bytes(#bufSeg(#buf(32, Y8), 24, 8)) )))
-;           { THIS
-;           | ListItem(45506446345753628416285423056165511379837572639148407563471291220684748896453) /* keccak256("DepositEvent(bytes,bytes,bytes,bytes,bytes)") */
-;           |  #buf(32, 5 *Int 32)
-;           ++ #buf(32, 5 *Int 32 +Int 96)
-;           ++ #buf(32, 5 *Int 32 +Int 96 +Int 64)
-;           ++ #buf(32, 5 *Int 32 +Int 96 +Int 64 +Int 64)
-;           ++ #buf(32, 5 *Int 32 +Int 96 +Int 64 +Int 64 +Int 128)
-;           ++ #buf(32, {PUBKEY_LENGTH})                 ++ #buf({PUBKEY_LENGTH}, PUBKEY) ++ #buf(16, 0)
-;           ++ #buf(32, {WITHDRAWAL_CREDENTIALS_LENGTH}) ++ #buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)
-;           ++ #buf(32, 8)                               ++ #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0)
-;           ++ #buf(32, {SIGNATURE_LENGTH})              ++ #buf({SIGNATURE_LENGTH}, SIGNATURE)
-;           ++ #buf(32, 8)                               ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0)
-;           }
 
-[deposit-revert-1]
-k: #execute => #halt
-status_code: _ => EVMC_REVERT
-pc: 0 => 1691
-word_stack: .WordStack => _
-local_mem: .Map => _
-CONDITIONS:
-    // conditions
-    andBool DEPOSIT_COUNT >=Int {MAX_DEPOSIT_COUNT}
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
-GAS_COST: 620
-MEM_COST: 672
-
-[deposit-revert-2]
-k: #execute => #halt
-status_code: _ => EVMC_REVERT
-pc: 0 => 1743
-word_stack: .WordStack => _
-local_mem: .Map => _
-CONDITIONS:
-    // conditions
-    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
-    andBool CALL_VALUE /Int {GWEI_IN_WEI} <Int {MIN_DEPOSIT_AMOUNT}
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
-GAS_COST: 697
-MEM_COST: 768
-
-[deposit-revert-3]
-k: #execute => #halt
-status_code: _ => EVMC_REVERT
-pc: 0 => 4018
-word_stack: .WordStack => _
-local_mem: .Map => _
-log: _ => _
-CONDITIONS:
-    // conditions
-    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
-    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
-    andBool {NODE} =/=Int DEPOSIT_DATA_ROOT
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MU_DATA}, .Set)
-GAS_COST: 769 +Int 10925 +Int 12354 +Int 17029 +Int 14371
-
-[deposit-add]
+[deposit-success-insert]
 WORD_STACK_INIT: 32 : 3360 : .WordStack
 
-[deposit-add-init]
-;
+[deposit-success-insert-init]
+LOCAL_MEM_DATA: MEM
+    {VYPER_GENERATED_BOUNDS}
+    ; locals
+    [ 2784 := #buf(32, {NODE}) ]      /* node */
 
-[deposit-add-init-then]
+[deposit-success-insert-init-then]
 k: #execute => #halt
 output: _ => .WordStack
 status_code: _ => EVMC_SUCCESS
 pc: {PC_ADD_BEGIN} => {PC_ADD_END}
 word_stack: .WordStack
-local_mem: MEM
-    {VYPER_GENERATED_BOUNDS}
-    ; locals
-    [ 2784 := #buf(32, {NODE}) ]      /* node */
-    => _
+local_mem: {LOCAL_MEM_DATA} => _
 storage: M => M
     [ #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList) <- DEPOSIT_COUNT +Int 1 ]
     [ #hashedLocation({COMPILER}, {BRANCH}, 0)               <- {NODE} ]
@@ -581,14 +521,10 @@ refund: _ => _
 gas:         #symGas(G, 0 => 11019, 0 => 41019, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem({MU_DATA} => {MU_ADD_ODD}, .Set)
 
-[deposit-add-init-else]
+[deposit-success-insert-init-else]
 pc: {PC_ADD_BEGIN} => {PC_ADD_LOOPHEAD}
 word_stack: .WordStack => 1 : {WORD_STACK_INIT}
-local_mem: MEM
-    {VYPER_GENERATED_BOUNDS}
-    ; locals
-    [ 2784 := #buf(32, {NODE}) ]      /* node */
-    => NEW_MEM
+local_mem: {LOCAL_MEM_DATA} => NEW_MEM
 +ensures:
     {ENSURES_VYPER_GENERATED_BOUNDS}
     andBool #range(NEW_MEM, 2784, 32) ==K #buf(32, {NODE_1})
@@ -605,7 +541,7 @@ refund: _ => _
 gas:         #symGas(G, 0 => 7196, 0 => 22196, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem({MU_DATA} => {MU_ADD_EVEN}, .Set)
 
-[deposit-add-loop]
+[deposit-success-insert-loop]
 LOCAL_MEM_LOOPHEAD: MEM
     {VYPER_GENERATED_BOUNDS}
     ; locals
@@ -619,12 +555,12 @@ LOCAL_MEM_LOOPHEAD: MEM
     andBool #rangeUInt(256, NODE)
     andBool #rangeUInt(256, SIZE)
 
-[deposit-add-loop-enter]
+[deposit-success-insert-loop-enter]
 +requires:
     // conditions
     andBool HEIGHT <Int 32
 
-[deposit-add-loop-enter-then]
+[deposit-success-insert-loop-enter-then]
 k: #execute => #halt
 output: _ => .WordStack
 status_code: _ => EVMC_SUCCESS
@@ -640,7 +576,7 @@ refund: _ => _
 gas:         #symGas(G, 0 => 5162, 0 => 20162, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem({MU_ADD_EVEN}, .Set)
 
-[deposit-add-loop-enter-else]
+[deposit-success-insert-loop-enter-else]
 pc: {PC_ADD_LOOPHEAD}
 word_stack: (HEIGHT => HEIGHT +Int 1) : {WORD_STACK_INIT}
 local_mem: {LOCAL_MEM_LOOPHEAD} => NEW_MEM
@@ -658,7 +594,7 @@ gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}
 memory_used: #symMem({MU_ADD_EVEN}, .Set)
 GAS_COST: 1339
 
-[deposit-add-loop-exit]
+[deposit-success-insert-loop-exit]
 k: #execute => #halt
 output: _ => .WordStack
 status_code: _ => EVMC_SUCCESS
@@ -671,6 +607,161 @@ local_mem: {LOCAL_MEM_LOOPHEAD}
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem({MU_ADD_EVEN}, .Set)
 GAS_COST: 27
+
+[deposit-revert]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+word_stack: .WordStack => _
+local_mem: .Map => _
+log: _ => _
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MEM_COST}, .Set)
+
+[deposit-revert-1]
+pc: 0 => 1691
++requires:
+    // conditions
+    andBool DEPOSIT_COUNT >=Int {MAX_DEPOSIT_COUNT}
+GAS_COST: 620
+MEM_COST: 672
+
+[deposit-revert-2]
+pc: 0 => 1743
++requires:
+    // conditions
+    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
+    andBool CALL_VALUE /Int {GWEI_IN_WEI} <Int {MIN_DEPOSIT_AMOUNT}
+GAS_COST: 697
+MEM_COST: 768
+
+[deposit-revert-3]
+pc: 0 => 4018
++requires:
+    // conditions
+    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
+    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
+    andBool {NODE} =/=Int DEPOSIT_DATA_ROOT
+GAS_COST: 769 +Int 10925 +Int 12354 +Int 17029 +Int 14371
+MEM_COST: {MU_DATA}
+
+[deposit-calldata-decoding]
+; arbitrary calldata including ill-formed one
+call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
++requires:
+    // conditions
+    andBool {FUNCTION_SELECTOR} ==Int 579424536 /* 0x22895118 deposit */
+    andBool CALL_DATA_SIZE >=Int 4
+    // conditions
+    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
+    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MEM_COST}, .Set)
+;
+CALLDATALOAD_0: #take(32, {CALL_DATA})
+FUNCTION_SELECTOR: #asWord(#take(4, {CALLDATALOAD_0}))
+;
+PUBKEY_OFFSET:                 (4 +Word #asWord({CALL_DATA}[  4 .. 32 ]))
+WITHDRAWAL_CREDENTIALS_OFFSET: (4 +Word #asWord({CALL_DATA}[ 36 .. 32 ]))
+SIGNATURE_OFFSET:              (4 +Word #asWord({CALL_DATA}[ 68 .. 32 ]))
+;
+PUBKEY_ARRAY:                 ({CALL_DATA}[ {PUBKEY_OFFSET}                 .. (32 +Int {PUBKEY_LENGTH}                ) ])
+WITHDRAWAL_CREDENTIALS_ARRAY: ({CALL_DATA}[ {WITHDRAWAL_CREDENTIALS_OFFSET} .. (32 +Int {WITHDRAWAL_CREDENTIALS_LENGTH}) ])
+SIGNATURE_ARRAY:              ({CALL_DATA}[ {SIGNATURE_OFFSET}              .. (32 +Int {SIGNATURE_LENGTH}             ) ])
+;
+PUBKEY_ARRAY_SIZE:                 #asWord(#take(32, {PUBKEY_ARRAY}))
+WITHDRAWAL_CREDENTIALS_ARRAY_SIZE: #asWord(#take(32, {WITHDRAWAL_CREDENTIALS_ARRAY}))
+SIGNATURE_ARRAY_SIZE:              #asWord(#take(32, {SIGNATURE_ARRAY}))
+
+[deposit-calldata-decoding-success]
+; until the length check
+pc: 0 => {PC_SUBCALL_1}
+word_stack: .WordStack
+local_mem: .Map => .Map
+    ; function hash
+    [   28 := {CALLDATALOAD_0} ]
+    {VYPER_GENERATED_BOUNDS}
+    ; load calldata
+    [  320 := {PUBKEY_ARRAY} ]
+    [  448 := {WITHDRAWAL_CREDENTIALS_ARRAY} ]
+    [  544 := {SIGNATURE_ARRAY} ]
+    [  736 := #buf(32, {GWEI_IN_WEI}) ]                             /* 1 gwei = 10^9 wei */
+    [  704 := #buf(32, {DEPOSIT_AMOUNT}) ]                          /* deposit_amount: uint256 = msg.value / as_wei_value(1, "gwei") */
++requires:
+    // conditions
+    andBool {PUBKEY_ARRAY_SIZE}                 ==Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE} ==Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}              ==Int {SIGNATURE_LENGTH}
+GAS_COST: 769
+MEM_COST: {MU_INIT}
+
+[deposit-calldata-decoding-revert]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+word_stack: .WordStack => _
+local_mem: .Map => _
+
+[deposit-calldata-decoding-revert-1]
+pc: 0 => 1609
++requires:
+    // conditions
+    andBool {PUBKEY_ARRAY_SIZE}                   >Int {PUBKEY_LENGTH}
+GAS_COST: 261
+MEM_COST: 400
+
+[deposit-calldata-decoding-revert-2]
+pc: 0 => 1641
++requires:
+    // conditions
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}   >Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+GAS_COST: 326
+MEM_COST: 512
+
+[deposit-calldata-decoding-revert-3]
+pc: 0 => 1673
++requires:
+    // conditions
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}                >Int {SIGNATURE_LENGTH}
+GAS_COST: 397
+MEM_COST: 672
+
+[deposit-calldata-decoding-revert-4]
+pc: 0 => 1759
++requires:
+    // conditions
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
+    andBool {PUBKEY_ARRAY_SIZE}                 =/=Int {PUBKEY_LENGTH}
+GAS_COST: 723
+MEM_COST: 768
+
+[deposit-calldata-decoding-revert-5]
+pc: 0 => 1775
++requires:
+    // conditions
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
+    andBool {PUBKEY_ARRAY_SIZE}                  ==Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE} =/=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+GAS_COST: 749
+MEM_COST: 768
+
+[deposit-calldata-decoding-revert-6]
+pc: 0 => 1791
++requires:
+    // conditions
+    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
+    andBool {PUBKEY_ARRAY_SIZE}                  ==Int {PUBKEY_LENGTH}
+    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  ==Int {WITHDRAWAL_CREDENTIALS_LENGTH}
+    andBool {SIGNATURE_ARRAY_SIZE}              =/=Int {SIGNATURE_LENGTH}
+GAS_COST: 775
+MEM_COST: 768
 
 ;
 ; revert cases
@@ -712,115 +803,6 @@ MEM_COST: 192
 +requires:
     // conditions
     andBool CALL_DATA_SIZE >=Int 32
-
-; without calldata well-formedness condition
-
-[deposit-init-calldata]
-call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
-pc: 0 => {PC_SUBCALL_1}
-word_stack: .WordStack
-local_mem: .Map => {LOCAL_MEM_INIT}
-LOCAL_MEM_INIT: .Map
-    ; function hash
-    [   28 := {CALLDATALOAD_0} ]
-    {VYPER_GENERATED_BOUNDS}
-    ; load calldata
-    [  320 := {PUBKEY_ARRAY} ]
-    [  448 := {WITHDRAWAL_CREDENTIALS_ARRAY} ]
-    [  544 := {SIGNATURE_ARRAY} ]
-    [  736 := #buf(32, {GWEI_IN_WEI}) ]                             /* 1 gwei = 10^9 wei */
-    [  704 := #buf(32, {DEPOSIT_AMOUNT}) ]                          /* deposit_amount: uint256 = msg.value / as_wei_value(1, "gwei") */
-+requires:
-    // conditions
-    andBool {FUNCTION_SELECTOR} ==Int 579424536 /* 0x22895118 deposit */
-    andBool CALL_DATA_SIZE >=Int 4
-    {LENGTH_CHECK}
-LENGTH_CHECK:
-    andBool {PUBKEY_ARRAY_SIZE}                 ==Int {PUBKEY_LENGTH}
-    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE} ==Int {WITHDRAWAL_CREDENTIALS_LENGTH}
-    andBool {SIGNATURE_ARRAY_SIZE}              ==Int {SIGNATURE_LENGTH}
-CALLDATALOAD_0: #take(32, {CALL_DATA})
-FUNCTION_SELECTOR: #asWord(#take(4, {CALLDATALOAD_0}))
-;
-PUBKEY_OFFSET:                 (4 +Word #asWord({CALL_DATA}[  4 .. 32 ]))
-WITHDRAWAL_CREDENTIALS_OFFSET: (4 +Word #asWord({CALL_DATA}[ 36 .. 32 ]))
-SIGNATURE_OFFSET:              (4 +Word #asWord({CALL_DATA}[ 68 .. 32 ]))
-;
-PUBKEY_ARRAY:                 ({CALL_DATA}[ {PUBKEY_OFFSET}                 .. (32 +Int {PUBKEY_LENGTH}                ) ])
-WITHDRAWAL_CREDENTIALS_ARRAY: ({CALL_DATA}[ {WITHDRAWAL_CREDENTIALS_OFFSET} .. (32 +Int {WITHDRAWAL_CREDENTIALS_LENGTH}) ])
-SIGNATURE_ARRAY:              ({CALL_DATA}[ {SIGNATURE_OFFSET}              .. (32 +Int {SIGNATURE_LENGTH}             ) ])
-;
-PUBKEY_ARRAY_SIZE:                 #asWord(#take(32, {PUBKEY_ARRAY}))
-WITHDRAWAL_CREDENTIALS_ARRAY_SIZE: #asWord(#take(32, {WITHDRAWAL_CREDENTIALS_ARRAY}))
-SIGNATURE_ARRAY_SIZE:              #asWord(#take(32, {SIGNATURE_ARRAY}))
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MU_INIT}, .Set)
-GAS_COST: 769
-
-[deposit-init-calldata-revert]
-k: #execute => #halt
-status_code: _ => EVMC_REVERT
-word_stack: .WordStack => _
-local_mem: .Map => _
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
-
-[deposit-init-calldata-revert-1]
-pc: 0 => 1609
-LENGTH_CHECK:
-    andBool {PUBKEY_ARRAY_SIZE}                   >Int {PUBKEY_LENGTH}
-GAS_COST: 261
-MEM_COST: 400
-
-[deposit-init-calldata-revert-2]
-pc: 0 => 1641
-LENGTH_CHECK:
-    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
-    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}   >Int {WITHDRAWAL_CREDENTIALS_LENGTH}
-GAS_COST: 326
-MEM_COST: 512
-
-[deposit-init-calldata-revert-3]
-pc: 0 => 1673
-LENGTH_CHECK:
-    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
-    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
-    andBool {SIGNATURE_ARRAY_SIZE}                >Int {SIGNATURE_LENGTH}
-GAS_COST: 397
-MEM_COST: 672
-
-[deposit-init-calldata-revert-4]
-pc: 0 => 1759
-LENGTH_CHECK:
-    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
-    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
-    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
-    andBool {PUBKEY_ARRAY_SIZE}                 =/=Int {PUBKEY_LENGTH}
-GAS_COST: 723
-MEM_COST: 768
-
-[deposit-init-calldata-revert-5]
-pc: 0 => 1775
-LENGTH_CHECK:
-    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
-    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
-    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
-    andBool {PUBKEY_ARRAY_SIZE}                  ==Int {PUBKEY_LENGTH}
-    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE} =/=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
-GAS_COST: 749
-MEM_COST: 768
-
-[deposit-init-calldata-revert-6]
-pc: 0 => 1791
-LENGTH_CHECK:
-    andBool {PUBKEY_ARRAY_SIZE}                  <=Int {PUBKEY_LENGTH}
-    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  <=Int {WITHDRAWAL_CREDENTIALS_LENGTH}
-    andBool {SIGNATURE_ARRAY_SIZE}               <=Int {SIGNATURE_LENGTH}
-    andBool {PUBKEY_ARRAY_SIZE}                  ==Int {PUBKEY_LENGTH}
-    andBool {WITHDRAWAL_CREDENTIALS_ARRAY_SIZE}  ==Int {WITHDRAWAL_CREDENTIALS_LENGTH}
-    andBool {SIGNATURE_ARRAY_SIZE}              =/=Int {SIGNATURE_LENGTH}
-GAS_COST: 775
-MEM_COST: 768
 
 ;
 ; globals

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -59,56 +59,6 @@ ENSURES_VYPER_GENERATED_BOUNDS:
     andBool #range(NEW_MEM,  96, 32) ==K #buf(32, 115792089237316195423570985008687907853099843482180094807725896704197245534208)
     andBool #range(NEW_MEM, 128, 32) ==K #buf(32, 1701411834604692317316873037158841057270000000000)
     andBool #range(NEW_MEM, 160, 32) ==K #buf(32, 115792089237316195423570985006986496018665292348323691002298742950633129639936)
-LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT:
-    [ 352 /* = 320 + 32 *  1      */ := #buf(32, {RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64}) ]  /* return address */
-    [ 320 /* = 320 + 32 *  0      */ := #buf(32, DEPOSIT_COUNT) ]  /* argument */
-    [ 384 /* = 320 + 32 *  2      */ := #buf(32, Y8) ]             /* y: uint256 = (y << 8) + bitwise_and(x, 255) */
-    [ 416 /* = 320 + 32 *  3      */ := #buf(32, X8) ]             /* x: uint256 = (x >> 8) */
-    [ 448 /* = 320 + 32 *  4      */ := #buf(32, 8) ]              /* for-loop index */
-    [ 480 /* = 320 + 32 *  5      */ := #buf(32, X7 &Int 255) ]    /* bitwise_and(x, 255) */
-    [ 544 /* = 320 + 32 *  7      */ := #buf(32, Y8) ]             /* memcpy(544 <- 384, 32) */
-    [ 536 /* = 320 + 32 *  6 + 24 */ := #buf(32, 8) ]              /* for slice(convert(y, bytes32), start=24, len=8) */
-    [ 704 /* = 320 + 32 * 12      */ := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ]  /* return: bytes[8] */ /* memcpy(704 <- 536, 40) */
-    {TO_LITTLE_ENDIAN_64_ZERO_PADDING}
-LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT:
-    [ 352 /* = 320 + 32 *  1      */ := #buf(32, {RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT}) ]  /* return address */
-    [ 320 /* = 320 + 32 *  0      */ := #buf(32, {DEPOSIT_AMOUNT}) ]   /* argument */
-    [ 384 /* = 320 + 32 *  2      */ := #buf(32, YY8) ]                /* y: uint256 = (y << 8) + bitwise_and(x, 255) */
-    [ 416 /* = 320 + 32 *  3      */ := #buf(32, XX8) ]                /* x: uint256 = (x >> 8) */
-    [ 448 /* = 320 + 32 *  4      */ := #buf(32, 8) ]                  /* for-loop index */
-    [ 480 /* = 320 + 32 *  5      */ := #buf(32, XX7 &Int 255) ]       /* bitwise_and(x, 255) */
-    [ 544 /* = 320 + 32 *  7      */ := #buf(32, YY8) ]                /* memcpy(544 <- 384, 32) */
-    [ 536 /* = 320 + 32 *  6 + 24 */ := #buf(32, 8) ]                  /* for slice(convert(y, bytes32), start=24, len=8) */
-    [ 704 /* = 320 + 32 * 12      */ := #buf(32, 8) ++ #bufSeg(#buf(32, YY8), 24, 8) ]  /* return: bytes[8] */ /* memcpy(704 <- 536, 40) */
-    {TO_LITTLE_ENDIAN_64_ZERO_PADDING}
-TO_LITTLE_ENDIAN_64_ZERO_PADDING:
-    [ 800 /* = 320 + 32 * 15      */ := #buf(32, 32) ]             /* padding loop index */
-    [ 744 /* = 320 + 32 * 13 +  8 */ <- 0 ]                        /* padding */
-    [ 745 /* = 320 + 32 * 13 +  9 */ <- 0 ]
-    [ 746 /* = 320 + 32 * 13 + 10 */ <- 0 ]
-    [ 747 /* = 320 + 32 * 13 + 11 */ <- 0 ]
-    [ 748 /* = 320 + 32 * 13 + 12 */ <- 0 ]
-    [ 749 /* = 320 + 32 * 13 + 13 */ <- 0 ]
-    [ 750 /* = 320 + 32 * 13 + 14 */ <- 0 ]
-    [ 751 /* = 320 + 32 * 13 + 15 */ <- 0 ]
-    [ 752 /* = 320 + 32 * 13 + 16 */ <- 0 ]
-    [ 753 /* = 320 + 32 * 13 + 17 */ <- 0 ]
-    [ 754 /* = 320 + 32 * 13 + 18 */ <- 0 ]
-    [ 755 /* = 320 + 32 * 13 + 19 */ <- 0 ]
-    [ 756 /* = 320 + 32 * 13 + 20 */ <- 0 ]
-    [ 757 /* = 320 + 32 * 13 + 21 */ <- 0 ]
-    [ 758 /* = 320 + 32 * 13 + 22 */ <- 0 ]
-    [ 759 /* = 320 + 32 * 13 + 23 */ <- 0 ]
-    [ 760 /* = 320 + 32 * 13 + 24 */ <- 0 ]
-    [ 761 /* = 320 + 32 * 13 + 25 */ <- 0 ]
-    [ 762 /* = 320 + 32 * 13 + 26 */ <- 0 ]
-    [ 763 /* = 320 + 32 * 13 + 27 */ <- 0 ]
-    [ 764 /* = 320 + 32 * 13 + 28 */ <- 0 ]
-    [ 765 /* = 320 + 32 * 13 + 29 */ <- 0 ]
-    [ 766 /* = 320 + 32 * 13 + 30 */ <- 0 ]
-    [ 767 /* = 320 + 32 * 13 + 31 */ <- 0 ]
-    [ 672 /* = 320 + 32 * 11      */ := #buf(32, 32) ]             /* ??? */
-    [ 640 /* = 320 + 32 * 10      */ := #buf(32, 0) ]              /* ??? */
 LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT:
     // let-bindings
     andBool X1 ==Int DEPOSIT_COUNT /Int 256
@@ -151,11 +101,6 @@ LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT:
 ;
 ; __init__
 ;
-
-; @public
-; def __init__():
-;     for i in range(DEPOSIT_CONTRACT_TREE_DEPTH - 1):
-;         self.zero_hashes[i + 1] = sha256(concat(self.zero_hashes[i], self.zero_hashes[i]))
 
 [init]
 ; for create
@@ -283,118 +228,6 @@ pc: 0 => 151
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem(0 => 192, .Set)
 GAS_COST: 69
-
-;
-; to_little_endian_64
-;
-
-[to_little_endian_64-trusted]
-gas:         #symGas(G, LB => LB +Int {GAS_COST}, UB => UB +Int {GAS_COST}, GS, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(MU => maxInt(MU, {MEM_COST}), MUS)
-attribute: [trusted, matching(#symGas,#symMem,Cmem)]
-
-[to_little_endian_64]
-k: #execute
-pc: {PC_BEGIN} => {PC_END}
-word_stack: {WORD_STACK_BEGIN} => {WORD_STACK_END}
-local_mem: {LOCAL_MEM_BEGIN} => {LOCAL_MEM_END}
-LOOP_BOUND: 8
-SLICE_LENGTH: 8
-PC_BEGIN:  169
-PC_MIDDLE: 387
-PC_END:    636
-WORD_STACK_BEGIN:  RETURN_ADDR : VALUE                 : WS /* WS saves caller's local vars */
-WORD_STACK_MIDDLE: {LOOP_BOUND} : 448                  : WS
-WORD_STACK_END:    RETURN_ADDR : 32 : 8 : {RETURN_VAL} : WS
-; RETURN_VAL: selectRange({LOCAL_MEM_END}, 736, 32)
-RETURN_VAL: #asWord(#bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0))
-LOCAL_MEM_BEGIN:  MEM
-LOCAL_MEM_MIDDLE: {LOCAL_MEM_BEGIN}  {LOCAL_MEM_UPDATE_FROM_BEGIN_TO_MIDDLE}
-LOCAL_MEM_END:    {LOCAL_MEM_MIDDLE} {LOCAL_MEM_UPDATE_FROM_MIDDLE_TO_END}
-LOCAL_MEM_UPDATE_FROM_BEGIN_TO_MIDDLE:
-    [ 352 /* = 320 + 32 *  1      */ := #buf(32, RETURN_ADDR) ]
-    [ 320 /* = 320 + 32 *  0      */ := #buf(32, VALUE) ]
-    [ 384 /* = 320 + 32 *  2      */ := #buf(32, Y8) ]             /* y: uint256 = (y << 8) + bitwise_and(x, 255) */
-    [ 416 /* = 320 + 32 *  3      */ := #buf(32, X8) ]             /* x: uint256 = (x >> 8) */
-    [ 448 /* = 320 + 32 *  4      */ := #buf(32, {LOOP_BOUND}) ]   /* for-loop index */
-    [ 480 /* = 320 + 32 *  5      */ := #buf(32, X7 &Int 255) ]    /* bitwise_and(x, 255) */
-LOCAL_MEM_UPDATE_FROM_MIDDLE_TO_END:
-    [ 544 /* = 320 + 32 *  7      */ := #buf(32, Y8) ]             /* memcpy(544 <- 384, 32) */
-    [ 536 /* = 320 + 32 *  6 + 24 */ := #buf(32, {SLICE_LENGTH}) ] /* for slice(convert(y, bytes32), start=24, len=8) */
-    [ 704 /* = 320 + 32 * 12      */ := #buf(32, {SLICE_LENGTH}) ++ #bufSeg(#buf(32, Y8), 24, {SLICE_LENGTH}) ]    /* return: bytes[8] */ /* memcpy(704 <- 536, 40) */
-    {TO_LITTLE_ENDIAN_64_ZERO_PADDING}
-+requires:
-    // conditions
-    andBool #range(0 <= #sizeWordStack(WS) <= 1000) // NOTE: rough bound
-    andBool #rangeUInt(256, RETURN_ADDR)
-    andBool #rangeUInt(256, VALUE)
-    // let-bindings
-    andBool X1 ==Int VALUE /Int 256
-    andBool X2 ==Int X1    /Int 256
-    andBool X3 ==Int X2    /Int 256
-    andBool X4 ==Int X3    /Int 256
-    andBool X5 ==Int X4    /Int 256
-    andBool X6 ==Int X5    /Int 256
-    andBool X7 ==Int X6    /Int 256
-    andBool X8 ==Int X7    /Int 256
-    //
-    andBool Y1 ==Int                  VALUE &Int 255
-    andBool Y2 ==Int (Y1 *Int 256) +Int (X1 &Int 255)
-    andBool Y3 ==Int (Y2 *Int 256) +Int (X2 &Int 255)
-    andBool Y4 ==Int (Y3 *Int 256) +Int (X3 &Int 255)
-    andBool Y5 ==Int (Y4 *Int 256) +Int (X4 &Int 255)
-    andBool Y6 ==Int (Y5 *Int 256) +Int (X5 &Int 255)
-    andBool Y7 ==Int (Y6 *Int 256) +Int (X6 &Int 255)
-    andBool Y8 ==Int (Y7 *Int 256) +Int (X7 &Int 255)
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
-GAS_COST: 7556
-MEM_COST: 832
-
-[to_little_endian_64-forloop]
-pc: {PC_BEGIN} => {PC_MIDDLE}
-word_stack: {WORD_STACK_BEGIN} => {WORD_STACK_MIDDLE}
-local_mem: {LOCAL_MEM_BEGIN} => {LOCAL_MEM_MIDDLE}
-;   ; save call stack args
-;   [ 352 := #buf(32, RETURN_ADDR) ]
-;   [ 320 := #buf(32, VALUE) ]
-;   ; init locals
-;   [ 384 := #buf(32, 0) ]                  /* y: uint256 = 0 */
-;   [ 416 := #buf(32, VALUE) ]              /* x: uint256 = value */
-;   [ 448 := #buf(32, 0) ]                  /* init for-loop index */
-;   ; loop body (pc: 189 <-> 372)
-;   [ 384 := #buf(32, 0) ]                  /* y = shift(y, 8) */ /* y << 8 */
-;   [ 480 := #buf(32, VALUE &Int 255) ]     /* bitwise_and(x, 255) */
-;   [ 384 := #buf(32, VALUE &Int 255) ]     /* y = y + bitwise_and(x, 255) */
-;   [ 416 := #buf(32, VALUE /Int 256) ]     /* x = shift(x, -8) */ /* x >> 8 */
-;   [ 448 := #buf(32, 1) ]                  /* increase for-loop index */
-;   ; ... repeat loop body ...
-gas: #symGas(G, 0, 0, .List, Cmem({SCHEDULE}, #symMem(0, .Set))) => _
-memory_used: #symMem(0, .Set) => _
-
-[to_little_endian_64-return]
-pc: {PC_MIDDLE} => {PC_END}
-word_stack: {WORD_STACK_MIDDLE} => {WORD_STACK_END}
-local_mem: {LOCAL_MEM_MIDDLE} => {LOCAL_MEM_END}
-;   [ 544 := #buf(32, Y8) ]                 /* memcpy 544 <- 384 */
-;   [ 536 := #buf(32, 8) ]                  /* slice by overwrite */
-;   [ 704 := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8)) ]         /* prepareing for return value*/
-;
-;   [ 800 := #buf(32, 8) ]
-;   [ 744 <- 0 ]
-;   [ 800 := #buf(32, 9) ]
-;   [ 745 <- 0 ]
-;   ...
-;   [ 767 <- 0 ]                            /* padding */
-;   [ 800 := #buf(32, 32) ]                 /* padding loop index */
-;
-;   [ 672 := #buf(32, 32) ]
-;   [ 640 := #buf(32, 96) ]
-;   [ 640 := #buf(32, 64) ]
-;   [ 640 := #buf(32, 32) ]
-;   [ 640 := #buf(32, 0) ]
-gas: #symGas(G, 0, 0, .List, Cmem({SCHEDULE}, #symMem(0, .Set))) => _
-memory_used: #symMem(0, .Set) => _
 
 ;
 ; get_deposit_root
@@ -607,232 +440,6 @@ MAX_DEPOSIT_COUNT:  4294967295
 GWEI_IN_WEI:        1000000000
 MIN_DEPOSIT_AMOUNT: 1000000000
 DEPOSIT_AMOUNT: (CALL_VALUE /Int {GWEI_IN_WEI})
-LOCAL_MEM_BEGIN: .Map
-    {LOCAL_MEM_DEPOSIT_FUNCTION_HASH}
-    {VYPER_GENERATED_BOUNDS}
-LOCAL_MEM_DEPOSIT_FUNCTION_HASH:
-    ; function hash
-    [  28 <-  34 ]
-    [  29 <- 137 ]
-    [  30 <-  81 ]
-    [  31 <-  24 ]
-LOCAL_MEM_INIT: {LOCAL_MEM_BEGIN}
-    ; load calldata
-    [  320 /* = 320 + 32 *  0 */ := #buf(32, 48) ++ #buf(48, PUBKEY) ]                    /* calldatacopy(416, 100,  80) */
-    [  448 /* = 320 + 32 *  4 */ := #buf(32, 32) ++ #buf(32, WITHDRAWAL_CREDENTIALS) ]    /* calldatacopy(544, 196,  64) */
-    [  544 /* = 320 + 32 *  7 */ := #buf(32, 96) ++ #buf(96, SIGNATURE) ]                 /* calldatacopy(640, 260, 128) */
-    [  736 /* = 320 + 32 * 13 */ := #buf(32, {GWEI_IN_WEI}) ]                             /* 1 gwei = 10^9 wei */
-    [  704 /* = 320 + 32 * 12 */ := #buf(32, {DEPOSIT_AMOUNT}) ]                          /* deposit_amount: uint256 = msg.value / as_wei_value(1, "gwei") */
-LOCAL_MEM_SUBCALL_1: {LOCAL_MEM_INIT}
-    ; before call
-    [  864 /* = 320 + 32 * 17 */ := #buf(32, 288) ]                                       /* memcpy loop index */
-    [  896 /* = 320 + 32 * 18 */ := #buf(32, 2154246793) ]                                /* ??? */
-    [  928 /* = 320 + 32 * 19 */ := #buf(32, {DEPOSIT_AMOUNT}) ]
-    ; call to_little_endian_64
-    {LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT}
-    ; after call
-    [ 1024 /* = 320 + 32 * 22 */ := #buf(32, 8) ]
-    [ 1120 /* = 320 + 32 * 25 */ := #buf(32, 0) ]
-    [ 1056 /* = 320 + 32 * 23 */ := #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0) ]
-    [ 1120 /* = 320 + 32 * 25 */ := #buf(32, 32) ]
-    ; restore stack
-    [  832 /* = 320 + 32 * 16 */ := #buf(32, 0) ]
-    [  800 /* = 320 + 32 * 15 */ := #buf(32, 0) ]
-    [  768 /* = 320 + 32 * 14 */ := #buf(32, 0) ]
-    [  736 /* = 320 + 32 * 13 */ := #buf(32, {GWEI_IN_WEI}) ]
-    [  704 /* = 320 + 32 * 12 */ := #buf(32, {DEPOSIT_AMOUNT}) ]
-    [  672 /* = 320 + 32 * 11 */ := #buf(32, 0) ]
-    [  640 /* = 320 + 32 * 10 */ := #bufSeg(#buf(96, SIGNATURE), 64, 32) ]
-    [  608 /* = 320 + 32 *  9 */ := #bufSeg(#buf(96, SIGNATURE), 32, 32) ]
-    [  576 /* = 320 + 32 *  8 */ := #bufSeg(#buf(96, SIGNATURE),  0, 32) ]
-    [  544 /* = 320 + 32 *  7 */ := #buf(32, 96) ]
-    [  512 /* = 320 + 32 *  6 */ := #buf(32, 0) ]
-    [  480 /* = 320 + 32 *  5 */ := #buf(32, WITHDRAWAL_CREDENTIALS) ]
-    [  448 /* = 320 + 32 *  4 */ := #buf(32, 32) ]
-    [  416 /* = 320 + 32 *  3 */ := #buf(32, 0) ]
-    [  384 /* = 320 + 32 *  2 */ := #bufSeg(#buf(48, PUBKEY), 32, 16) ++ #buf(16, 0) ]
-    [  352 /* = 320 + 32 *  1 */ := #bufSeg(#buf(48, PUBKEY),  0, 32) ]
-    [  320 /* = 320 + 32 *  0 */ := #buf(32, 48) ]
-    ; copy result
-    [  768 /* = 320 + 32 * 14 */ := #buf(32, 8) ++ #bufSeg(#buf(32, YY8), 24, 8) ]    /* memcpy(768 <- 1024, 40) */ /* amount: bytes[8] = self.to_little_endian_64(deposit_amount) */
-LOCAL_MEM_SUBCALL_2: {LOCAL_MEM_SUBCALL_1}
-    ; before call
-    [ 1152 /* = 320 + 32 * 26 */ := #buf(32, 288) ]                                       /* memcpy loop index */
-    [ 1184 /* = 320 + 32 * 27 */ := #buf(32, 2154246793) ]                                /* ??? */
-    [ 1216 /* = 320 + 32 * 28 */ := #buf(32, DEPOSIT_COUNT) ]
-    ; call to_little_endian_64
-    {LOCAL_MEM_UPDATE_BY_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
-    ; after call
-    [ 1312 /* = 320 + 32 * 31 */ := #buf(32, 8) ]
-    [ 1408 /* = 320 + 32 * 34 */ := #buf(32, 0) ]
-    [ 1344 /* = 320 + 32 * 32 */ := #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0) ]
-    [ 1408 /* = 320 + 32 * 34 */ := #buf(32, 32) ]
-    ; restore stack
-    [ 1120 /* = 320 + 32 * 25 */ := #buf(32, 32) ]
-    [ 1088 /* = 320 + 32 * 24 */ := #buf(32, 0) ]
-    [ 1056 /* = 320 + 32 * 23 */ := #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0) ]
-    [ 1024 /* = 320 + 32 * 22 */ := #buf(32, 8) ]
-    [  992 /* = 320 + 32 * 21 */ := #buf(32, 0) ]
-    [  960 /* = 320 + 32 * 20 */ := #buf(32, 0) ]
-    [  928 /* = 320 + 32 * 19 */ := #buf(32, {DEPOSIT_AMOUNT}) ]
-    [  896 /* = 320 + 32 * 18 */ := #buf(32, 2154246793) ]
-    [  864 /* = 320 + 32 * 17 */ := #buf(32, 288) ]
-    [  832 /* = 320 + 32 * 16 */ := #buf(32, 0) ]
-    [  800 /* = 320 + 32 * 15 */ := #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0) ]
-    [  768 /* = 320 + 32 * 14 */ := #buf(32, 8) ]
-    [  736 /* = 320 + 32 * 13 */ := #buf(32, {GWEI_IN_WEI}) ]
-    [  704 /* = 320 + 32 * 12 */ := #buf(32, {DEPOSIT_AMOUNT}) ]
-    [  672 /* = 320 + 32 * 11 */ := #buf(32, 0) ]
-    [  640 /* = 320 + 32 * 10 */ := #bufSeg(#buf(96, SIGNATURE), 64, 32) ]
-    [  608 /* = 320 + 32 *  9 */ := #bufSeg(#buf(96, SIGNATURE), 32, 32) ]
-    [  576 /* = 320 + 32 *  8 */ := #bufSeg(#buf(96, SIGNATURE),  0, 32) ]
-    [  544 /* = 320 + 32 *  7 */ := #buf(32, 96) ]
-    [  512 /* = 320 + 32 *  6 */ := #buf(32, 0) ]
-    [  480 /* = 320 + 32 *  5 */ := #buf(32, WITHDRAWAL_CREDENTIALS) ]
-    [  448 /* = 320 + 32 *  4 */ := #buf(32, 32) ]
-    [  416 /* = 320 + 32 *  3 */ := #buf(32, 0) ]
-    [  384 /* = 320 + 32 *  2 */ := #bufSeg(#buf(48, PUBKEY), 32, 16) ++ #buf(16, 0) ]
-    [  352 /* = 320 + 32 *  1 */ := #bufSeg(#buf(48, PUBKEY),  0, 32) ]
-    [  320 /* = 320 + 32 *  0 */ := #buf(32, 48) ]
-    ; copy result
-    [ 1440 /* = 320 + 32 * 35 */ := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ] /* memcpy(1440 <- 1312, 40) */
-RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT: 1864
-RETURN_ADDR_FROM_TO_LITTLE_ENDIAN_64:                2080
-LOCAL_MEM_LOG: {LOCAL_MEM_SUBCALL_2}
-    ; local memory chunk from 1632 to 2207 stores the DepositEvent log data
-    ; see [deposit-log]
-    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 160) ]                                       /* offset pointer */
-    [ 1632 /* = 1632 + 32 *  0      */ := #buf(32, 160) ]                                       /* offset to pubkey */
-    [ 1792 /* = 1632 + 32 *  5      */ := #buf(32, 48) ++ #buf(48, PUBKEY) ]                    /* pubkey */ /* memcpy(1792 <- 320, 80) */
-    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 64) ]                                        /* padding index */
-    [ 1872 /* = 1632 + 32 *  7 + 16 */ <- 0 ]
-    [ 1873 /* = 1632 + 32 *  7 + 17 */ <- 0 ]
-    [ 1874 /* = 1632 + 32 *  7 + 18 */ <- 0 ]
-    [ 1875 /* = 1632 + 32 *  7 + 19 */ <- 0 ]
-    [ 1876 /* = 1632 + 32 *  7 + 20 */ <- 0 ]
-    [ 1877 /* = 1632 + 32 *  7 + 21 */ <- 0 ]
-    [ 1878 /* = 1632 + 32 *  7 + 22 */ <- 0 ]
-    [ 1879 /* = 1632 + 32 *  7 + 23 */ <- 0 ]
-    [ 1880 /* = 1632 + 32 *  7 + 24 */ <- 0 ]
-    [ 1881 /* = 1632 + 32 *  7 + 25 */ <- 0 ]
-    [ 1882 /* = 1632 + 32 *  7 + 26 */ <- 0 ]
-    [ 1883 /* = 1632 + 32 *  7 + 27 */ <- 0 ]
-    [ 1884 /* = 1632 + 32 *  7 + 28 */ <- 0 ]
-    [ 1885 /* = 1632 + 32 *  7 + 29 */ <- 0 ]
-    [ 1886 /* = 1632 + 32 *  7 + 30 */ <- 0 ]
-    [ 1887 /* = 1632 + 32 *  7 + 31 */ <- 0 ]
-    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 256) ]
-    [ 1664 /* = 1632 + 32 *  1      */ := #buf(32, 256) ]                                       /* offset to withdrawal_credentials */
-    [ 1888 /* = 1632 + 32 *  8      */ := #buf(32, 32) ++ #buf(32, WITHDRAWAL_CREDENTIALS) ]    /* withdrawal_credentials */ /* memcpy(1888 <- 448, 64) */
-    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 32) ]                                        /* padding index */
-    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 320) ]
-    [ 1696 /* = 1632 + 32 *  2      */ := #buf(32, 320) ]                                       /* offset to amount */
-    [ 1952 /* = 1632 + 32 * 10      */ := #buf(32, 8) ++ #bufSeg(#buf(32, YY8), 24, 8) ]        /* amount */ /* memcpy(1952 <- 768, 40) */
-    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 32) ]                                        /* padding index */
-    [ 1992 /* = 1632 + 32 * 11 +  8 */ <- 0 ]
-    [ 1993 /* = 1632 + 32 * 11 +  9 */ <- 0 ]
-    [ 1994 /* = 1632 + 32 * 11 + 10 */ <- 0 ]
-    [ 1995 /* = 1632 + 32 * 11 + 11 */ <- 0 ]
-    [ 1996 /* = 1632 + 32 * 11 + 12 */ <- 0 ]
-    [ 1997 /* = 1632 + 32 * 11 + 13 */ <- 0 ]
-    [ 1998 /* = 1632 + 32 * 11 + 14 */ <- 0 ]
-    [ 1999 /* = 1632 + 32 * 11 + 15 */ <- 0 ]
-    [ 2000 /* = 1632 + 32 * 11 + 16 */ <- 0 ]
-    [ 2001 /* = 1632 + 32 * 11 + 17 */ <- 0 ]
-    [ 2002 /* = 1632 + 32 * 11 + 18 */ <- 0 ]
-    [ 2003 /* = 1632 + 32 * 11 + 19 */ <- 0 ]
-    [ 2004 /* = 1632 + 32 * 11 + 20 */ <- 0 ]
-    [ 2005 /* = 1632 + 32 * 11 + 21 */ <- 0 ]
-    [ 2006 /* = 1632 + 32 * 11 + 22 */ <- 0 ]
-    [ 2007 /* = 1632 + 32 * 11 + 23 */ <- 0 ]
-    [ 2008 /* = 1632 + 32 * 11 + 24 */ <- 0 ]
-    [ 2009 /* = 1632 + 32 * 11 + 25 */ <- 0 ]
-    [ 2010 /* = 1632 + 32 * 11 + 26 */ <- 0 ]
-    [ 2011 /* = 1632 + 32 * 11 + 27 */ <- 0 ]
-    [ 2012 /* = 1632 + 32 * 11 + 28 */ <- 0 ]
-    [ 2013 /* = 1632 + 32 * 11 + 29 */ <- 0 ]
-    [ 2014 /* = 1632 + 32 * 11 + 30 */ <- 0 ]
-    [ 2015 /* = 1632 + 32 * 11 + 31 */ <- 0 ]
-    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 384) ]
-    [ 1728 /* = 1632 + 32 *  3      */ := #buf(32, 384) ]                                       /* offset to signature */
-    [ 2016 /* = 1632 + 32 * 12      */ := #buf(32, 96) ++ #buf(96, SIGNATURE) ]                 /* signature */ /* memcpy(<- 544, 128) */
-    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 96) ]                                        /* padding index */
-    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 512) ]
-    [ 1760 /* = 1632 + 32 *  4      */ := #buf(32, 512) ]                                       /* offset to deposit_count */
-    [ 2144 /* = 1632 + 32 * 16      */ := #buf(32, 8) ++ #bufSeg(#buf(32, Y8), 24, 8) ]         /* deposit_count */ /* memcpy(<- 1440, 40) */
-    [ 1536 /* =  320 + 32 * 38      */ := #buf(32, 32) ]                                        /* padding index */
-    [ 2184 /* = 1632 + 32 * 17 +  8 */ <- 0 ]
-    [ 2185 /* = 1632 + 32 * 17 +  9 */ <- 0 ]
-    [ 2186 /* = 1632 + 32 * 17 + 10 */ <- 0 ]
-    [ 2187 /* = 1632 + 32 * 17 + 11 */ <- 0 ]
-    [ 2188 /* = 1632 + 32 * 17 + 12 */ <- 0 ]
-    [ 2189 /* = 1632 + 32 * 17 + 13 */ <- 0 ]
-    [ 2190 /* = 1632 + 32 * 17 + 14 */ <- 0 ]
-    [ 2191 /* = 1632 + 32 * 17 + 15 */ <- 0 ]
-    [ 2192 /* = 1632 + 32 * 17 + 16 */ <- 0 ]
-    [ 2193 /* = 1632 + 32 * 17 + 17 */ <- 0 ]
-    [ 2194 /* = 1632 + 32 * 17 + 18 */ <- 0 ]
-    [ 2195 /* = 1632 + 32 * 17 + 19 */ <- 0 ]
-    [ 2196 /* = 1632 + 32 * 17 + 20 */ <- 0 ]
-    [ 2197 /* = 1632 + 32 * 17 + 21 */ <- 0 ]
-    [ 2198 /* = 1632 + 32 * 17 + 22 */ <- 0 ]
-    [ 2199 /* = 1632 + 32 * 17 + 23 */ <- 0 ]
-    [ 2200 /* = 1632 + 32 * 17 + 24 */ <- 0 ]
-    [ 2201 /* = 1632 + 32 * 17 + 25 */ <- 0 ]
-    [ 2202 /* = 1632 + 32 * 17 + 26 */ <- 0 ]
-    [ 2203 /* = 1632 + 32 * 17 + 27 */ <- 0 ]
-    [ 2204 /* = 1632 + 32 * 17 + 28 */ <- 0 ]
-    [ 2205 /* = 1632 + 32 * 17 + 29 */ <- 0 ]
-    [ 2206 /* = 1632 + 32 * 17 + 30 */ <- 0 ]
-    [ 2207 /* = 1632 + 32 * 17 + 31 */ <- 0 ]
-    [ 1568 /* =  320 + 32 * 39      */ := #buf(32, 576) ]                                       /* offset pointer = size of log data */
-LOCAL_MEM_DATA: {LOCAL_MEM_LOG}
-    ; see [deposit-data]
-    [ 1792 := #buf(32, 0) ]                             /* zero_bytes32: bytes32 = 0x0000000000000000000000000000000000000000000000000000000000000000 */
-    ; compute pubkey_root
-    [ 2016 := #buf(48, PUBKEY) ]                        /* memcpy(<- 352, 48) */
-    [ 1888 := #buf(32, 0) ]                             /* memcpy(<- 1792, 32) */
-    [ 1856 := #buf(32, 16) ]                            /* len=64 - PUBKEY_LENGTH */
-    [ 2064 := #buf(16, 0) ]                             /* memcpy(<- 1888, 16) */
-    [ 1984 := #buf(32, 64) ]
-    [  192 := #buf(32, {PUBKEY_ROOT}) ]                 /* sha256(2016, 64) */
-    [ 1824 := #buf(32, {PUBKEY_ROOT}) ]                 /* pubkey_root: bytes32 = sha256(concat(pubkey, slice(zero_bytes32, start=0, len=64 - PUBKEY_LENGTH))) */
-    ; compute tmp1
-    [ 2176 := #buf(96, SIGNATURE) ]                     /* memcpy(<- 576, 96) */
-    [ 2144 := #buf(32, 64) ]
-    [  192 := #buf(32, {TMP1}) ]                        /* sha256(2176, 64) */
-    [ 2688 := #buf(32, {TMP1}) ]                        /* sha256(slice(signature, start=0, len=64)), */
-    ; compute tmp2
-    [ 2368 := #bufSeg(#buf(96, SIGNATURE), 64, 32) ++ #buf(32, 0) ++ #buf(32, {DEPOSIT_AMOUNT}) ]   /* memcpy(<- 640, 96) */   /* TODO: ??? */
-    [ 2336 := #buf(32, 32) ]                            /* len=SIGNATURE_LENGTH - 64 */
-    [ 2560 := #bufSeg(#buf(96, SIGNATURE), 64, 32) ]    /* memcpy(<- 2368, 32) */
-    [ 2592 := #buf(32, 0) ]
-    [ 2528 := #buf(32, 64) ]
-    [  192 := #buf(32, {TMP2}) ]                        /* sha256(2560, 64) */
-    [ 2720 := #buf(32, {TMP2}) ]                        /* sha256(concat(slice(signature, start=64, len=SIGNATURE_LENGTH - 64), zero_bytes32)), */
-    ; compute signature_root
-    [ 2656 := #buf(32, 64) ]
-    [  192 := #buf(32, {SIGNATURE_ROOT}) ]              /* sha256(2688, 64) */
-    [ 2112 := #buf(32, {SIGNATURE_ROOT}) ]              /* signature_root: bytes32 = sha256(concat(...)) */
-    ; compute tmp3
-    [ 2848 := #buf(32, {PUBKEY_ROOT}) ]
-    [ 2880 := #buf(32, WITHDRAWAL_CREDENTIALS) ]        /* memcpy(<- 480, 32) */
-    [ 2816 := #buf(32, 64) ]
-    [  192 := #buf(32, {TMP3}) ]                        /* sha256(2848, 64) */
-    [ 3232 := #buf(32, {TMP3}) ]                        /* sha256(concat(pubkey_root, withdrawal_credentials)), */
-    ; compute tmp4
-    [ 3104 := #bufSeg(#buf(32, YY8), 24, 8) ]           /* memcpy(<- 800, 8) */
-    [ 2976 := #buf(32, 0) ]                             /* memcpy(<- 1792, 32) */
-    [ 2944 := #buf(32, 24) ]                            /* len=32 - AMOUNT_LENGTH */
-    [ 3112 := #buf(24, 0) ]                             /* memcpy(<- 2976, 24) */
-    [ 3136 := #buf(32, {SIGNATURE_ROOT}) ]
-    [ 3072 := #buf(32, 64) ]
-    [  192 := #buf(32, {TMP4}) ]                        /* sha256(3104, 64) */
-    [ 3264 := #buf(32, {TMP4}) ]                        /* sha256(concat(amount, slice(zero_bytes32, start=0, len=32 - AMOUNT_LENGTH), signature_root)), */
-    ; compute node
-    [ 3200 := #buf(32, 64) ]
-    [  192 := #buf(32, {NODE}) ]                        /* sha256(3232, 64) */
-    [ 2784 := #buf(32, {NODE}) ]                        /* node: bytes32 = sha256(concat(...)) */
 PUBKEY_ROOT: #sha256(#buf(48, PUBKEY) ++ #buf(16, 0))
 TMP1: #sha256(#bufSeg(#buf(96, SIGNATURE), 0, 64))
 TMP2: #sha256(#bufSeg(#buf(96, SIGNATURE), 64, 32) ++ #buf(32, 0))
@@ -841,47 +448,68 @@ TMP3: #sha256(#buf(32, {PUBKEY_ROOT}) ++ #buf(32, WITHDRAWAL_CREDENTIALS))
 TMP4: #sha256(#bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0) ++ #buf(32, {SIGNATURE_ROOT}))
 NODE: #sha256(#buf(32, {TMP3}) ++ #buf(32, {TMP4}))
 PC_SUBCALL_1:    1792
-PC_SUBCALL_2:    2010
-PC_LOG:          2226
-PC_DATA:         3143
 PC_ADD_BEGIN:    4020
 PC_ADD_LOOPHEAD: 4260
 PC_ADD_END:      4270
 MU_INIT:          768
-MU_SUBCALL_1:    1152
-MU_SUBCALL_2:    1480
-MU_LOG:          2208
 MU_DATA:         3296
 MU_ADD_ODD:      3392
 MU_ADD_EVEN:     3488
 
-; @payable
-; @public
-; def deposit(pubkey: bytes[PUBKEY_LENGTH],
-;             withdrawal_credentials: bytes[WITHDRAWAL_CREDENTIALS_LENGTH],
-;             signature: bytes[SIGNATURE_LENGTH],
-;             deposit_data_root: bytes32):
+; #### `DepositData`
 ;
-;     # Avoid overflowing the Merkle tree (and prevent edge case in computing `self.branch`)
-;     assert self.deposit_count < MAX_DEPOSIT_COUNT
-;
-;     # Validate deposit data
-;     deposit_amount: uint256 = msg.value / as_wei_value(1, "gwei")
-;     assert deposit_amount >= MIN_DEPOSIT_AMOUNT
-;     assert len(pubkey) == PUBKEY_LENGTH
-;     assert len(withdrawal_credentials) == WITHDRAWAL_CREDENTIALS_LENGTH
-;     assert len(signature) == SIGNATURE_LENGTH
+; ```python
+; class DepositData(Container):
+;     pubkey: BLSPubkey
+;     withdrawal_credentials: Hash
+;     amount: Gwei
+;     signature: BLSSignature
+; ```
 
-[deposit-init]
-pc: 0 => {PC_SUBCALL_1}
+;                                    ___________________________ node _________________________
+;                                   /                                                          \
+;                    __________ tmp3 ___________________                        ______________ tmp4 _______________
+;                   /                                   \                      /                                   \
+;           pubkey_root                       withdrawal_credentials       amount                        _____ signature_root __________
+;           /       \                                                                                   /                               \
+;   pubkey[0:32]  pubkey[32:48]++zero[0:16]                                                           tmp1                             tmp2
+;                                                                                                  /       \                        /        \
+;                                                                                       signature[0:32]  signature[32:64]  signature[64:96]  zero[0:32]
+
+[deposit-data]
+pc: 0 => {PC_ADD_BEGIN}
 word_stack: .WordStack
-local_mem: .Map => {LOCAL_MEM_INIT}
-; gas usage = 765 + ( 82 = 3*n + n^2 / 512 where n = 27 = 864 / 32 )
+local_mem: .Map => NEW_MEM
++ensures:
+    {ENSURES_VYPER_GENERATED_BOUNDS}
+    andBool #range(NEW_MEM, 2784, 32) ==K #buf(32, {NODE})
++CONDITIONS:
+    // conditions
+    andBool {NODE} ==Int DEPOSIT_DATA_ROOT
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MU_INIT}, .Set)
-GAS_COST: 769
+memory_used: #symMem(0 => {MU_DATA}, .Set)
+GAS_COST: 769 +Int 10925 +Int 12354 +Int 17029 +Int 14366
+log: _:List ( .List => ListItem(#abiEventLog(THIS, "DepositEvent",
+            #bytes(#buf({PUBKEY_LENGTH}, PUBKEY)),
+            #bytes(#buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)),
+            #bytes(#bufSeg(#buf(32, YY8), 24, 8)),
+            #bytes(#buf({SIGNATURE_LENGTH}, SIGNATURE)),
+            #bytes(#bufSeg(#buf(32, Y8), 24, 8)) )))
+;           { THIS
+;           | ListItem(45506446345753628416285423056165511379837572639148407563471291220684748896453) /* keccak256("DepositEvent(bytes,bytes,bytes,bytes,bytes)") */
+;           |  #buf(32, 5 *Int 32)
+;           ++ #buf(32, 5 *Int 32 +Int 96)
+;           ++ #buf(32, 5 *Int 32 +Int 96 +Int 64)
+;           ++ #buf(32, 5 *Int 32 +Int 96 +Int 64 +Int 64)
+;           ++ #buf(32, 5 *Int 32 +Int 96 +Int 64 +Int 64 +Int 128)
+;           ++ #buf(32, {PUBKEY_LENGTH})                 ++ #buf({PUBKEY_LENGTH}, PUBKEY) ++ #buf(16, 0)
+;           ++ #buf(32, {WITHDRAWAL_CREDENTIALS_LENGTH}) ++ #buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)
+;           ++ #buf(32, 8)                               ++ #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0)
+;           ++ #buf(32, {SIGNATURE_LENGTH})              ++ #buf({SIGNATURE_LENGTH}, SIGNATURE)
+;           ++ #buf(32, 8)                               ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0)
+;           }
 
-[deposit-init-revert-1]
+[deposit-revert-1]
 k: #execute => #halt
 status_code: _ => EVMC_REVERT
 pc: 0 => 1691
@@ -895,7 +523,7 @@ memory_used: #symMem(0 => {MEM_COST}, .Set)
 GAS_COST: 620
 MEM_COST: 672
 
-[deposit-init-revert-2]
+[deposit-revert-2]
 k: #execute => #halt
 status_code: _ => EVMC_REVERT
 pc: 0 => 1743
@@ -910,13 +538,192 @@ memory_used: #symMem(0 => {MEM_COST}, .Set)
 GAS_COST: 697
 MEM_COST: 768
 
+[deposit-revert-3]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+pc: 0 => 4018
+word_stack: .WordStack => _
+local_mem: .Map => _
+log: _ => _
+CONDITIONS:
+    // conditions
+    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
+    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
+    andBool {NODE} =/=Int DEPOSIT_DATA_ROOT
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MU_DATA}, .Set)
+GAS_COST: 769 +Int 10925 +Int 12354 +Int 17029 +Int 14371
+
+[deposit-add]
+WORD_STACK_INIT: 32 : 3360 : .WordStack
+
+[deposit-add-init]
+;
+
+[deposit-add-init-then]
+k: #execute => #halt
+output: _ => .WordStack
+status_code: _ => EVMC_SUCCESS
+pc: {PC_ADD_BEGIN} => {PC_ADD_END}
+word_stack: .WordStack
+local_mem: MEM
+    {VYPER_GENERATED_BOUNDS}
+    ; locals
+    [ 2784 := #buf(32, {NODE}) ]      /* node */
+    => _
+storage: M => M
+    [ #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList) <- DEPOSIT_COUNT +Int 1 ]
+    [ #hashedLocation({COMPILER}, {BRANCH}, 0)               <- {NODE} ]
+refund: _ => _
++requires:
+    // conditions
+    andBool (DEPOSIT_COUNT +Int 1) &Int 1 ==Int 1
+gas:         #symGas(G, 0 => 11019, 0 => 41019, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_DATA} => {MU_ADD_ODD}, .Set)
+
+[deposit-add-init-else]
+pc: {PC_ADD_BEGIN} => {PC_ADD_LOOPHEAD}
+word_stack: .WordStack => 1 : {WORD_STACK_INIT}
+local_mem: MEM
+    {VYPER_GENERATED_BOUNDS}
+    ; locals
+    [ 2784 := #buf(32, {NODE}) ]      /* node */
+    => NEW_MEM
++ensures:
+    {ENSURES_VYPER_GENERATED_BOUNDS}
+    andBool #range(NEW_MEM, 2784, 32) ==K #buf(32, {NODE_1})
+    andBool #range(NEW_MEM, 3328, 32) ==K #buf(32, (DEPOSIT_COUNT +Int 1) /Int 2)
+    andBool #range(NEW_MEM, 3360, 32) ==K #buf(32, 1)
+NODE_1: #sha256(#buf(32, {BRANCH_0}) ++ #buf(32, {NODE}))
+BRANCH_0: select(M, #hashedLocation({COMPILER}, {BRANCH}, 0))
+storage: M => M
+    [ #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList) <- DEPOSIT_COUNT +Int 1 ]
+refund: _ => _
++requires:
+    // conditions
+    andBool (DEPOSIT_COUNT +Int 1) &Int 1 =/=Int 1
+gas:         #symGas(G, 0 => 7196, 0 => 22196, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_DATA} => {MU_ADD_EVEN}, .Set)
+
+[deposit-add-loop]
+LOCAL_MEM_LOOPHEAD: MEM
+    {VYPER_GENERATED_BOUNDS}
+    ; locals
+    [ 2784 := #buf(32, NODE) ]      /* node */
+    [ 3328 := #buf(32, SIZE) ]      /* size */
+    [ 3360 := #buf(32, HEIGHT) ]    /* height */
++requires:
+    // conditions
+    andBool #range(0 <= HEIGHT <= 32)
+    // types
+    andBool #rangeUInt(256, NODE)
+    andBool #rangeUInt(256, SIZE)
+
+[deposit-add-loop-enter]
++requires:
+    // conditions
+    andBool HEIGHT <Int 32
+
+[deposit-add-loop-enter-then]
+k: #execute => #halt
+output: _ => .WordStack
+status_code: _ => EVMC_SUCCESS
+pc: {PC_ADD_LOOPHEAD} => {PC_ADD_END}
+word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
+local_mem: {LOCAL_MEM_LOOPHEAD} => _
+storage: M => M
+    [ #hashedLocation({COMPILER}, {BRANCH}, HEIGHT) <- NODE ]
+refund: _ => _
++requires:
+    // conditions
+    andBool SIZE &Int 1 ==Int 1
+gas:         #symGas(G, 0 => 5162, 0 => 20162, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_ADD_EVEN}, .Set)
+
+[deposit-add-loop-enter-else]
+pc: {PC_ADD_LOOPHEAD}
+word_stack: (HEIGHT => HEIGHT +Int 1) : {WORD_STACK_INIT}
+local_mem: {LOCAL_MEM_LOOPHEAD} => NEW_MEM
++ensures:
+    {ENSURES_VYPER_GENERATED_BOUNDS}
+    andBool #range(NEW_MEM, 2784, 32) ==K #buf(32, {NODE_NEW})
+    andBool #range(NEW_MEM, 3328, 32) ==K #buf(32, SIZE /Int 2)
+    andBool #range(NEW_MEM, 3360, 32) ==K #buf(32, HEIGHT +Int 1)
+NODE_NEW: #sha256(#buf(32, {BRANCH_HEIGHT}) ++ #buf(32, NODE))
+BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
++requires:
+    // conditions
+    andBool SIZE &Int 1 =/=Int 1
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_ADD_EVEN}, .Set)
+GAS_COST: 1339
+
+[deposit-add-loop-exit]
+k: #execute => #halt
+output: _ => .WordStack
+status_code: _ => EVMC_SUCCESS
+pc: {PC_ADD_LOOPHEAD} => {PC_ADD_END}
+word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
+local_mem: {LOCAL_MEM_LOOPHEAD}
++requires:
+    // conditions
+    andBool HEIGHT ==Int 32
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({MU_ADD_EVEN}, .Set)
+GAS_COST: 27
+
+;
+; revert cases
+;
+
+[revert]
+k: #execute => #halt
+status_code: _ => EVMC_REVERT
+
+; Revert if the first four bytes are invalid (or not fully provided).
+[revert-invalid_function_identifier]
+call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
+pc: 0 => 4277
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MEM_COST}, .Set)
+
+[revert-invalid_function_identifier-lt_4]
++requires:
+    // conditions
+    andBool #range(0 <= CALL_DATA_SIZE < 4)
+GAS_COST: 42
+MEM_COST: 0
+
+[revert-invalid_function_identifier-ge_4]
++requires:
+    // conditions
+    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 3321006383 /* 0xc5f2892f get_deposit_root  */
+    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 1646252336 /* 0x621fd130 get_deposit_count */
+    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 579424536  /* 0x22895118 deposit           */
+GAS_COST: 196
+MEM_COST: 192
+
+[revert-invalid_function_identifier-ge_4-lt_32]
++requires:
+    // conditions
+    andBool #range(4 <= CALL_DATA_SIZE < 32)
+
+[revert-invalid_function_identifier-ge_4-ge_32]
++requires:
+    // conditions
+    andBool CALL_DATA_SIZE >=Int 32
+
 ; without calldata well-formedness condition
 
 [deposit-init-calldata]
 call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
-LOCAL_MEM_DEPOSIT_FUNCTION_HASH:
+pc: 0 => {PC_SUBCALL_1}
+word_stack: .WordStack
+local_mem: .Map => {LOCAL_MEM_INIT}
+LOCAL_MEM_INIT: .Map
+    ; function hash
     [   28 := {CALLDATALOAD_0} ]
-LOCAL_MEM_INIT: {LOCAL_MEM_BEGIN}
+    {VYPER_GENERATED_BOUNDS}
     ; load calldata
     [  320 := {PUBKEY_ARRAY} ]
     [  448 := {WITHDRAWAL_CREDENTIALS_ARRAY} ]
@@ -946,6 +753,9 @@ SIGNATURE_ARRAY:              ({CALL_DATA}[ {SIGNATURE_OFFSET}              .. (
 PUBKEY_ARRAY_SIZE:                 #asWord(#take(32, {PUBKEY_ARRAY}))
 WITHDRAWAL_CREDENTIALS_ARRAY_SIZE: #asWord(#take(32, {WITHDRAWAL_CREDENTIALS_ARRAY}))
 SIGNATURE_ARRAY_SIZE:              #asWord(#take(32, {SIGNATURE_ARRAY}))
+gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem(0 => {MU_INIT}, .Set)
+GAS_COST: 769
 
 [deposit-init-calldata-revert]
 k: #execute => #halt
@@ -1011,291 +821,6 @@ LENGTH_CHECK:
     andBool {SIGNATURE_ARRAY_SIZE}              =/=Int {SIGNATURE_LENGTH}
 GAS_COST: 775
 MEM_COST: 768
-
-;    # Emit `DepositEvent` log
-;    amount: bytes[8] = self.to_little_endian_64(deposit_amount)
-;    log.DepositEvent(pubkey, withdrawal_credentials, amount, signature, self.to_little_endian_64(self.deposit_count))
-
-[deposit-subcall_1]
-pc: {PC_SUBCALL_1} => {PC_SUBCALL_2}
-word_stack: .WordStack
-local_mem: {LOCAL_MEM_INIT} => {LOCAL_MEM_SUBCALL_1}
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_INIT} => {MU_SUBCALL_1}, .Set)
-GAS_COST: 10925
-
-[deposit-subcall_2]
-pc: {PC_SUBCALL_2} => {PC_LOG}
-word_stack: .WordStack
-local_mem: {LOCAL_MEM_SUBCALL_1} => {LOCAL_MEM_SUBCALL_2}
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_SUBCALL_1} => {MU_SUBCALL_2}, .Set)
-GAS_COST: 12354
-
-[deposit-log]
-pc: {PC_LOG} => {PC_DATA}
-word_stack: .WordStack
-local_mem: {LOCAL_MEM_SUBCALL_2} => {LOCAL_MEM_LOG}
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_SUBCALL_2} => {MU_LOG}, .Set)
-GAS_COST: 17029
-log: _:List ( .List => ListItem(#abiEventLog(THIS, "DepositEvent",
-            #bytes(#buf({PUBKEY_LENGTH}, PUBKEY)),
-            #bytes(#buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)),
-            #bytes(#bufSeg(#buf(32, YY8), 24, 8)),
-            #bytes(#buf({SIGNATURE_LENGTH}, SIGNATURE)),
-            #bytes(#bufSeg(#buf(32, Y8), 24, 8)) )))
-; log: _:List ( .List => ListItem({ THIS
-;                                 | ListItem(45506446345753628416285423056165511379837572639148407563471291220684748896453) /* keccak256("DepositEvent(bytes,bytes,bytes,bytes,bytes)") */
-;                                 |  #buf(32, 5 *Int 32)
-;                                 ++ #buf(32, 5 *Int 32 +Int 96)
-;                                 ++ #buf(32, 5 *Int 32 +Int 96 +Int 64)
-;                                 ++ #buf(32, 5 *Int 32 +Int 96 +Int 64 +Int 64)
-;                                 ++ #buf(32, 5 *Int 32 +Int 96 +Int 64 +Int 64 +Int 128)
-;                                 ++ #buf(32, {PUBKEY_LENGTH})                 ++ #buf({PUBKEY_LENGTH}, PUBKEY) ++ #buf(16, 0)
-;                                 ++ #buf(32, {WITHDRAWAL_CREDENTIALS_LENGTH}) ++ #buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)
-;                                 ++ #buf(32, 8)                               ++ #bufSeg(#buf(32, YY8), 24, 8) ++ #buf(24, 0)
-;                                 ++ #buf(32, {SIGNATURE_LENGTH})              ++ #buf({SIGNATURE_LENGTH}, SIGNATURE)
-;                                 ++ #buf(32, 8)                               ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0)
-;                                 }) )
-
-;    # Compute `DepositData` hash tree root
-;    zero_bytes32: bytes32 = 0x0000000000000000000000000000000000000000000000000000000000000000
-;    pubkey_root: bytes32 = sha256(concat(pubkey, slice(zero_bytes32, start=0, len=64 - PUBKEY_LENGTH)))
-;    signature_root: bytes32 = sha256(concat(
-;        sha256(slice(signature, start=0, len=64)),                                                             <-- tmp1
-;        sha256(concat(slice(signature, start=64, len=SIGNATURE_LENGTH - 64), zero_bytes32)),                   <-- tmp2
-;    ))
-;    node: bytes32 = sha256(concat(
-;        sha256(concat(pubkey_root, withdrawal_credentials)),                                                   <-- tmp3
-;        sha256(concat(amount, slice(zero_bytes32, start=0, len=32 - AMOUNT_LENGTH), signature_root)),          <-- tmp4
-;    ))
-;    # Verify computed and expected deposit data roots match
-;    assert node == deposit_data_root
-
-; #### `DepositData`
-;
-; ```python
-; class DepositData(Container):
-;     pubkey: BLSPubkey
-;     withdrawal_credentials: Hash
-;     amount: Gwei
-;     signature: BLSSignature
-; ```
-
-;                                    ___________________________ node _________________________
-;                                   /                                                          \
-;                    __________ tmp3 ___________________                        ______________ tmp4 _______________
-;                   /                                   \                      /                                   \
-;           pubkey_root                       withdrawal_credentials       amount                        _____ signature_root __________
-;           /       \                                                                                   /                               \
-;   pubkey[0:32]  pubkey[32:48]++zero[0:16]                                                           tmp1                             tmp2
-;                                                                                                  /       \                        /        \
-;                                                                                       signature[0:32]  signature[32:64]  signature[64:96]  zero[0:32]
-
-[deposit-data]
-pc: {PC_DATA} => {PC_ADD_BEGIN}
-word_stack: .WordStack
-local_mem: {LOCAL_MEM_LOG} => {LOCAL_MEM_DATA}
-+CONDITIONS:
-    // conditions
-    andBool {NODE} ==Int DEPOSIT_DATA_ROOT
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_LOG} => {MU_DATA}, .Set)
-GAS_COST: 14366
-
-[deposit-data-revert]
-k: #execute => #halt
-status_code: _ => EVMC_REVERT
-pc: {PC_DATA} => 4018
-word_stack: .WordStack => _
-local_mem: {LOCAL_MEM_LOG} => _
-CONDITIONS:
-    // conditions
-    andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
-    andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
-    andBool {NODE} =/=Int DEPOSIT_DATA_ROOT
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_LOG} => {MU_DATA}, .Set)
-GAS_COST: 14371
-
-;    # Add `DepositData` hash tree root to Merkle tree (update a single `branch` node)
-;    self.deposit_count += 1
-;    size: uint256 = self.deposit_count
-;    for height in range(DEPOSIT_CONTRACT_TREE_DEPTH):
-;        if bitwise_and(size, 1) == 1:  # More gas efficient than `size % 2 == 1`
-;            self.branch[height] = node
-;            break
-;        node = sha256(concat(self.branch[height], node))
-;        size /= 2
-
-[deposit-add]
-WORD_STACK_INIT: 32 : 3360 : .WordStack
-
-[deposit-add-init]
-;
-
-[deposit-add-init-then]
-k: #execute => #halt
-output: _ => .WordStack
-status_code: _ => EVMC_SUCCESS
-pc: {PC_ADD_BEGIN} => {PC_ADD_END}
-word_stack: .WordStack
-local_mem: {LOCAL_MEM_DATA} => {LOCAL_MEM_DATA}
-    [ 3328 := #buf(32, DEPOSIT_COUNT +Int 1) ]          /* size: uint256 = self.deposit_count */
-    [ 3360 := #buf(32, 0) ]                             /* height */
-    [  192 := #buf(32, 0) ]
-storage: M => M
-    [ #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList) <- DEPOSIT_COUNT +Int 1 ]
-    [ #hashedLocation({COMPILER}, {BRANCH}, 0)               <- {NODE} ]
-refund: _ => _
-+requires:
-    // conditions
-    andBool (DEPOSIT_COUNT +Int 1) &Int 1 ==Int 1
-gas:         #symGas(G, 0 => 11019, 0 => 41019, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_DATA} => {MU_ADD_ODD}, .Set)
-
-[deposit-add-init-else]
-pc: {PC_ADD_BEGIN} => {PC_ADD_LOOPHEAD}
-word_stack: .WordStack => 1 : {WORD_STACK_INIT}
-local_mem: {LOCAL_MEM_DATA} => {LOCAL_MEM_DATA}
-    [ 3328 := #buf(32, DEPOSIT_COUNT +Int 1) ]          /* size: uint256 = self.deposit_count */
-    [ 3360 := #buf(32, 0) ]                             /* height */
-    [  192 := #buf(32, 0) ]
-    [ 3424 := #buf(32, {BRANCH_0}) ]
-    [ 3456 := #buf(32, {NODE}) ]
-    [ 3392 := #buf(32, 64) ]
-    [  192 := #buf(32, {NODE_1}) ]                      /* sha256(3424, 64) */
-    [ 2784 := #buf(32, {NODE_1}) ]                      /* node = sha256(concat(self.branch[height], node)) */
-    [ 3328 := #buf(32, (DEPOSIT_COUNT +Int 1) /Int 2) ] /* update size */
-    [ 3360 := #buf(32, 1) ]                             /* update height */
-BRANCH_0: select(M, #hashedLocation({COMPILER}, {BRANCH}, 0))
-NODE_1: #sha256(#buf(32, {BRANCH_0}) ++ #buf(32, {NODE}))
-storage: M => M
-    [ #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList) <- DEPOSIT_COUNT +Int 1 ]
-refund: _ => _
-+requires:
-    // conditions
-    andBool (DEPOSIT_COUNT +Int 1) &Int 1 =/=Int 1
-gas:         #symGas(G, 0 => 7196, 0 => 22196, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_DATA} => {MU_ADD_EVEN}, .Set)
-
-[deposit-add-loop]
-LOCAL_MEM_LOOPHEAD: {LOCAL_MEM_DATA}
-    [ 3328 := #buf(32, SIZE) ]                      /* size */
-    [ 3360 := #buf(32, HEIGHT) ]                    /* height */
-    [  192 := #buf(32, 0) ]
-    [ 3424 := #buf(32, ANON_1) ]
-    [ 3456 := #buf(32, ANON_2) ]
-    [ 3392 := #buf(32, 64) ]
-    [  192 := #buf(32, NODE) ]                      /* sha256(3456, 64) */
-    [ 2784 := #buf(32, NODE) ]                      /* node = sha256(concat(self.branch[height], node)) */
-+requires:
-    // conditions
-    andBool #range(0 <= HEIGHT <= 32)
-    // types
-    andBool #rangeUInt(256, NODE)
-    andBool #rangeUInt(256, SIZE)
-    andBool #rangeUInt(256, ANON_1)
-    andBool #rangeUInt(256, ANON_2)
-
-[deposit-add-loop-enter]
-+requires:
-    // conditions
-    andBool HEIGHT <Int 32
-
-[deposit-add-loop-enter-then]
-k: #execute => #halt
-output: _ => .WordStack
-status_code: _ => EVMC_SUCCESS
-pc: {PC_ADD_LOOPHEAD} => {PC_ADD_END}
-word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
-local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
-    [  192 := #buf(32, 0) ]
-storage: M => M
-    [ #hashedLocation({COMPILER}, {BRANCH}, HEIGHT) <- NODE ]
-refund: _ => _
-+requires:
-    // conditions
-    andBool SIZE &Int 1 ==Int 1
-gas:         #symGas(G, 0 => 5162, 0 => 20162, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_ADD_EVEN}, .Set)
-
-[deposit-add-loop-enter-else]
-pc: {PC_ADD_LOOPHEAD}
-word_stack: (HEIGHT => HEIGHT +Int 1) : {WORD_STACK_INIT}
-local_mem: {LOCAL_MEM_LOOPHEAD} => {LOCAL_MEM_LOOPHEAD}
-    [  192 := #buf(32, 0) ]
-    [ 3424 := #buf(32, {BRANCH_HEIGHT}) ]
-    [ 3456 := #buf(32, NODE) ]
-    [ 3392 := #buf(32, 64) ]
-    [  192 := #buf(32, {NODE_NEW}) ]                    /* sha256(3456, 64) */
-    [ 2784 := #buf(32, {NODE_NEW}) ]                    /* node = sha256(concat(self.branch[height], node)) */
-    [ 3328 := #buf(32, SIZE /Int 2) ]                   /* update size */
-    [ 3360 := #buf(32, HEIGHT +Int 1) ]                 /* update height */
-BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
-NODE_NEW: #sha256(#buf(32, {BRANCH_HEIGHT}) ++ #buf(32, NODE))
-+requires:
-    // conditions
-    andBool SIZE &Int 1 =/=Int 1
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_ADD_EVEN}, .Set)
-GAS_COST: 1339
-
-[deposit-add-loop-exit]
-k: #execute => #halt
-output: _ => .WordStack
-status_code: _ => EVMC_SUCCESS
-pc: {PC_ADD_LOOPHEAD} => {PC_ADD_END}
-word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
-local_mem: {LOCAL_MEM_LOOPHEAD}
-+requires:
-    // conditions
-    andBool HEIGHT ==Int 32
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_ADD_EVEN}, .Set)
-GAS_COST: 27
-
-;
-; revert cases
-;
-
-[revert]
-k: #execute => #halt
-status_code: _ => EVMC_REVERT
-
-; Revert if the first four bytes are invalid (or not fully provided).
-[revert-invalid_function_identifier]
-call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
-pc: 0 => 4277
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
-
-[revert-invalid_function_identifier-lt_4]
-+requires:
-    // conditions
-    andBool #range(0 <= CALL_DATA_SIZE < 4)
-GAS_COST: 42
-MEM_COST: 0
-
-[revert-invalid_function_identifier-ge_4]
-+requires:
-    // conditions
-    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 3321006383 /* 0xc5f2892f get_deposit_root  */
-    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 1646252336 /* 0x621fd130 get_deposit_count */
-    andBool #asWord(#bufSeg(#buf(CALL_DATA_SIZE, CALL_DATA), 0, 4)) =/=Int 579424536  /* 0x22895118 deposit           */
-GAS_COST: 196
-MEM_COST: 192
-
-[revert-invalid_function_identifier-ge_4-lt_32]
-+requires:
-    // conditions
-    andBool #range(4 <= CALL_DATA_SIZE < 32)
-
-[revert-invalid_function_identifier-ge_4-ge_32]
-+requires:
-    // conditions
-    andBool CALL_DATA_SIZE >=Int 32
 
 ;
 ; globals


### PR DESCRIPTION
This simplifies the deposit spec, in a similar way to the previous simplification (#317 and #318).

- Now we have a single spec `[deposit-success-data]` that specifies the path from the beginning of the function to the beginning of the loop (i.e., [lines 71-99](https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/deposit_contract/contracts/validator_registration.vy#L71-L99)). That spec does not include the trusted to_little_endian_64 spec, as done in #317. 

- The loop specs are also simplified, similarly to #318. 