### PR TITLE
Deposit: further improvement of specs

### DIFF
--- a/deposit/bytecode-verification/Makefile
+++ b/deposit/bytecode-verification/Makefile
@@ -17,10 +17,10 @@ SPEC_NAMES:=
 SPEC_NAMES += init-success
 SPEC_NAMES += init-revert
 
-SPEC_NAMES += get_deposit_root-success-loop1-then
-SPEC_NAMES += get_deposit_root-success-loop1-else
-SPEC_NAMES += get_deposit_root-success-loop-body-then
-SPEC_NAMES += get_deposit_root-success-loop-body-else
+SPEC_NAMES += get_deposit_root-success-init-then
+SPEC_NAMES += get_deposit_root-success-init-else
+SPEC_NAMES += get_deposit_root-success-loop-enter-then
+SPEC_NAMES += get_deposit_root-success-loop-enter-else
 SPEC_NAMES += get_deposit_root-success-loop-exit
 SPEC_NAMES += get_deposit_root-revert
 

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -7,8 +7,8 @@ k: #execute
 pc: 0 => _
 word_stack: .WordStack => _
 local_mem: .Map => _
-gas: #symGas(G, 0, 0, .List, Cmem({SCHEDULE}, #symMem(0, .Set))) => _
-memory_used: #symMem(0, .Set) => _
+gas: #symGas(G, 0 => {GAS_COST_MIN}, 0 => {GAS_COST_MAX}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
+memory_used: #symMem({PRE_MEM_COST} => {MEM_COST}, .Set)
 ; no changes
 call_data: _
 log: _
@@ -46,6 +46,9 @@ requires:
     andBool isInitGas(G)
 ensures:
 attribute:
+GAS_COST_MIN: {GAS_COST}
+GAS_COST_MAX: {GAS_COST}
+PRE_MEM_COST: 0
 VYPER_GENERATED_BOUNDS:
     ; bounds - vyper generated
     [  32 := #buf(32, 1461501637330902918203684832716283019655932542976) ]
@@ -214,9 +217,8 @@ refund: _ => _
 +requires:
     // conditions
     andBool CALL_VALUE ==Int 0
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 4278, .Set)
 GAS_COST: 672893
+MEM_COST: 4278
 
 [init-revert]
 k: #execute => #halt
@@ -225,9 +227,8 @@ pc: 0 => 151
 +requires:
     // conditions
     andBool CALL_VALUE =/=Int 0
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 192, .Set)
 GAS_COST: 69
+MEM_COST: 192
 
 ;
 ; get_deposit_root
@@ -264,8 +265,6 @@ local_mem: .Map => NEW_MEM
     andBool #range(NEW_MEM, 352, 32) ==K #buf(32, {NODE_1})
     andBool #range(NEW_MEM, 384, 32) ==K #buf(32, DEPOSIT_COUNT /Int 2)
     andBool #range(NEW_MEM, 416, 32) ==K #buf(32, 1)
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
 
 [get_deposit_root-success-loop1-then]
 NODE_1: #sha256(#buf(32, {BRANCH_0}) ++ #buf(32, 0))
@@ -300,6 +299,7 @@ LOCAL_MEM_LOOPHEAD: MEM
     andBool #rangeUInt(256, NODE)
     andBool #rangeUInt(256, SIZE)
     andBool #rangeUInt(256, HEIGHT)
+PRE_MEM_COST: 672
 
 [get_deposit_root-success-loop-body]
 pc: {PC_LOOPHEAD}
@@ -314,8 +314,6 @@ local_mem: {LOCAL_MEM_LOOPHEAD} => NEW_MEM
 +requires:
     // conditions
     andBool HEIGHT =/=Int 32
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(672, .Set)
 
 [get_deposit_root-success-loop-body-then]
 NODE_NEW: #sha256(#buf(32, {BRANCH_HEIGHT}) ++ #buf(32, NODE))
@@ -324,6 +322,7 @@ BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
     // conditions
     andBool SIZE &Int 1 ==Int 1
 GAS_COST: 1350
+MEM_COST: 672
 
 [get_deposit_root-success-loop-body-else]
 NODE_NEW: #sha256(#buf(32, NODE) ++ #buf(32, {ZERO_HASHES_HEIGHT}))
@@ -332,6 +331,7 @@ ZERO_HASHES_HEIGHT: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, HEIGHT)
     // conditions
     andBool SIZE &Int 1 =/=Int 1
 GAS_COST: 1340
+MEM_COST: 672
 
 [get_deposit_root-success-loop-exit]
 k: #execute => #halt
@@ -345,9 +345,8 @@ local_mem: {LOCAL_MEM_LOOPHEAD} => _
     // conditions
     andBool HEIGHT ==Int 32
     {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(672 => 1216, .Set)
 GAS_COST: 11385
+MEM_COST: 1216
 
 [get_deposit_root-revert]
 k: #execute => #halt
@@ -356,9 +355,8 @@ pc: 0 => 663
 +requires:
     // conditions
     andBool CALL_VALUE =/=Int 0
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 192, .Set)
 GAS_COST: 154
+MEM_COST: 192
 
 ;
 ; get_deposit_count
@@ -386,9 +384,8 @@ local_mem: .Map => _
     // let-bindings
     andBool DEPOSIT_COUNT ==Int select(M, #hashedLocation({COMPILER}, {DEPOSIT_COUNT}, .IntList))
     {LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_COUNT}
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 832, .Set)
 GAS_COST: 11424
+MEM_COST: 832
 
 [get_deposit_count-revert]
 k: #execute => #halt
@@ -397,9 +394,8 @@ pc: 0 => 1318
 +requires:
     // conditions
     andBool CALL_VALUE =/=Int 0
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => 192, .Set)
 GAS_COST: 183
+MEM_COST: 192
 
 ;
 ; deposit
@@ -486,9 +482,8 @@ local_mem: .Map => NEW_MEM
 +ensures:
     {ENSURES_VYPER_GENERATED_BOUNDS}
     andBool #range(NEW_MEM, 2784, 32) ==K #buf(32, {NODE})
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MU_DATA}, .Set)
 GAS_COST: 769 +Int 10925 +Int 12354 +Int 17029 +Int 14366
+MEM_COST: {MU_DATA}
 log: _:List ( .List => ListItem(#abiEventLog(THIS, "DepositEvent",
             #bytes(#buf({PUBKEY_LENGTH}, PUBKEY)),
             #bytes(#buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)),
@@ -506,6 +501,7 @@ LOCAL_MEM_DATA: MEM
     {VYPER_GENERATED_BOUNDS}
     ; locals
     [ 2784 := #buf(32, {NODE}) ]      /* node */
+PRE_MEM_COST: {MU_DATA}
 
 [deposit-success-insert-init-then]
 k: #execute => #halt
@@ -521,8 +517,9 @@ refund: _ => _
 +requires:
     // conditions
     andBool (DEPOSIT_COUNT +Int 1) &Int 1 ==Int 1
-gas:         #symGas(G, 0 => 11019, 0 => 41019, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_DATA} => {MU_ADD_ODD}, .Set)
+GAS_COST_MIN: 11019
+GAS_COST_MAX: 41019
+MEM_COST: {MU_ADD_ODD}
 
 [deposit-success-insert-init-else]
 pc: {PC_ADD_BEGIN} => {PC_ADD_LOOPHEAD}
@@ -541,8 +538,9 @@ refund: _ => _
 +requires:
     // conditions
     andBool (DEPOSIT_COUNT +Int 1) &Int 1 =/=Int 1
-gas:         #symGas(G, 0 => 7196, 0 => 22196, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_DATA} => {MU_ADD_EVEN}, .Set)
+GAS_COST_MIN:  7196
+GAS_COST_MAX: 22196
+MEM_COST: {MU_ADD_EVEN}
 
 [deposit-success-insert-loop]
 LOCAL_MEM_LOOPHEAD: MEM
@@ -558,6 +556,7 @@ LOCAL_MEM_LOOPHEAD: MEM
     andBool #rangeUInt(256, NODE)
     andBool #rangeUInt(256, SIZE)
     andBool #rangeUInt(256, HEIGHT)
+PRE_MEM_COST: maxInt({MU_ADD_ODD}, {MU_ADD_EVEN})
 
 [deposit-success-insert-loop-enter]
 +requires:
@@ -577,8 +576,9 @@ refund: _ => _
 +requires:
     // conditions
     andBool SIZE &Int 1 ==Int 1
-gas:         #symGas(G, 0 => 5162, 0 => 20162, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_ADD_EVEN}, .Set)
+GAS_COST_MIN:  5162
+GAS_COST_MAX: 20162
+MEM_COST: maxInt({MU_ADD_ODD}, {MU_ADD_EVEN})
 
 [deposit-success-insert-loop-enter-else]
 pc: {PC_ADD_LOOPHEAD}
@@ -594,9 +594,8 @@ BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
 +requires:
     // conditions
     andBool SIZE &Int 1 =/=Int 1
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_ADD_EVEN}, .Set)
 GAS_COST: 1339
+MEM_COST: maxInt({MU_ADD_ODD}, {MU_ADD_EVEN})
 
 [deposit-success-insert-loop-exit]
 k: #execute => #halt
@@ -608,9 +607,8 @@ local_mem: {LOCAL_MEM_LOOPHEAD}
 +requires:
     // conditions
     andBool HEIGHT ==Int 32
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem({MU_ADD_EVEN}, .Set)
 GAS_COST: 27
+MEM_COST: maxInt({MU_ADD_ODD}, {MU_ADD_EVEN})
 
 [deposit-revert]
 k: #execute => #halt
@@ -618,8 +616,6 @@ status_code: _ => EVMC_REVERT
 word_stack: .WordStack => _
 local_mem: .Map => _
 log: _ => _
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
 
 [deposit-revert-1]
 pc: 0 => 1691
@@ -658,8 +654,6 @@ call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
     // conditions
     andBool DEPOSIT_COUNT <Int {MAX_DEPOSIT_COUNT}
     andBool CALL_VALUE /Int {GWEI_IN_WEI} >=Int {MIN_DEPOSIT_AMOUNT}
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
 ;
 CALLDATALOAD_0: #take(32, {CALL_DATA})
 FUNCTION_SELECTOR: #asWord(#take(4, {CALLDATALOAD_0}))
@@ -779,8 +773,6 @@ status_code: _ => EVMC_REVERT
 [revert-invalid_function_identifier]
 call_data: #buf(CALL_DATA_SIZE, CALL_DATA)
 pc: 0 => 4277
-gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
-memory_used: #symMem(0 => {MEM_COST}, .Set)
 
 [revert-invalid_function_identifier-lt_4]
 +requires:

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -497,7 +497,9 @@ log: _:List ( .List => ListItem(#abiEventLog(THIS, "DepositEvent",
             #bytes(#bufSeg(#buf(32, Y8), 24, 8)) )))
 
 [deposit-success-insert]
-WORD_STACK_INIT: 32 : 3360 : .WordStack
+WORD_STACK_INIT: {LOOP_BOUND} : {LOOP_INDEX_ADDR} : .WordStack
+LOOP_BOUND: 32
+LOOP_INDEX_ADDR: 3360
 
 [deposit-success-insert-init]
 LOCAL_MEM_DATA: MEM

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -337,8 +337,8 @@ MEM_COST: 672
 k: #execute => #halt
 status_code: _ => EVMC_SUCCESS
 pc: {PC_LOOPHEAD} => {PC_END}
-RETURN_VAL: #sha256(#buf(32, NODE) ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0))
 output: _ => #buf(32, {RETURN_VAL})
+RETURN_VAL: #sha256(#buf(32, NODE) ++ #bufSeg(#buf(32, Y8), 24, 8) ++ #buf(24, 0))
 word_stack: HEIGHT : {WORD_STACK_LOOP} => .WordStack
 local_mem: {LOCAL_MEM_LOOPHEAD} => _
 +requires:
@@ -482,14 +482,14 @@ local_mem: .Map => NEW_MEM
 +ensures:
     {ENSURES_VYPER_GENERATED_BOUNDS}
     andBool #range(NEW_MEM, 2784, 32) ==K #buf(32, {NODE})
-GAS_COST: 769 +Int 10925 +Int 12354 +Int 17029 +Int 14366
-MEM_COST: {MU_DATA}
 log: _:List ( .List => ListItem(#abiEventLog(THIS, "DepositEvent",
             #bytes(#buf({PUBKEY_LENGTH}, PUBKEY)),
             #bytes(#buf({WITHDRAWAL_CREDENTIALS_LENGTH}, WITHDRAWAL_CREDENTIALS)),
             #bytes(#bufSeg(#buf(32, YY8), 24, 8)),
             #bytes(#buf({SIGNATURE_LENGTH}, SIGNATURE)),
             #bytes(#bufSeg(#buf(32, Y8), 24, 8)) )))
+GAS_COST: 55443
+MEM_COST: {MU_DATA}
 
 [deposit-success-insert]
 WORD_STACK_INIT: {LOOP_BOUND} : {LOOP_INDEX_ADDR} : .WordStack
@@ -505,9 +505,9 @@ PRE_MEM_COST: {MU_DATA}
 
 [deposit-success-insert-init-then]
 k: #execute => #halt
-output: _ => .WordStack
 status_code: _ => EVMC_SUCCESS
 pc: {PC_ADD_BEGIN} => {PC_ADD_END}
+output: _ => .WordStack
 word_stack: .WordStack
 local_mem: {LOCAL_MEM_DATA} => _
 storage: M => M
@@ -565,9 +565,9 @@ PRE_MEM_COST: maxInt({MU_ADD_ODD}, {MU_ADD_EVEN})
 
 [deposit-success-insert-loop-enter-then]
 k: #execute => #halt
-output: _ => .WordStack
 status_code: _ => EVMC_SUCCESS
 pc: {PC_ADD_LOOPHEAD} => {PC_ADD_END}
+output: _ => .WordStack
 word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
 local_mem: {LOCAL_MEM_LOOPHEAD} => _
 storage: M => M
@@ -599,9 +599,9 @@ MEM_COST: maxInt({MU_ADD_ODD}, {MU_ADD_EVEN})
 
 [deposit-success-insert-loop-exit]
 k: #execute => #halt
-output: _ => .WordStack
 status_code: _ => EVMC_SUCCESS
 pc: {PC_ADD_LOOPHEAD} => {PC_ADD_END}
+output: _ => .WordStack
 word_stack: HEIGHT : {WORD_STACK_INIT} => .WordStack
 local_mem: {LOCAL_MEM_LOOPHEAD}
 +requires:

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -255,7 +255,7 @@ WORD_STACK_LOOP: {LOOP_BOUND} : {LOOP_INDEX_ADDR} : .WordStack
 LOOP_BOUND: 32
 LOOP_INDEX_ADDR: 416
 
-[get_deposit_root-success-loop1]
+[get_deposit_root-success-init]
 pc: 0 => {PC_LOOPHEAD}
 word_stack: .WordStack => 1 : {WORD_STACK_LOOP}
 local_mem: .Map => NEW_MEM
@@ -266,7 +266,7 @@ local_mem: .Map => NEW_MEM
     andBool #range(NEW_MEM, 384, 32) ==K #buf(32, DEPOSIT_COUNT /Int 2)
     andBool #range(NEW_MEM, 416, 32) ==K #buf(32, 1)
 
-[get_deposit_root-success-loop1-then]
+[get_deposit_root-success-init-then]
 NODE_1: #sha256(#buf(32, {BRANCH_0}) ++ #buf(32, 0))
 BRANCH_0: select(M, #hashedLocation({COMPILER}, {BRANCH}, 0))
 +requires:
@@ -275,7 +275,7 @@ BRANCH_0: select(M, #hashedLocation({COMPILER}, {BRANCH}, 0))
 GAS_COST: 1728
 MEM_COST: 672
 
-[get_deposit_root-success-loop1-else]
+[get_deposit_root-success-init-else]
 NODE_1: #sha256(#buf(32, 0) ++ #buf(32, {ZERO_HASHES_0}))
 ZERO_HASHES_0: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, 0))
 +requires:
@@ -301,7 +301,7 @@ LOCAL_MEM_LOOPHEAD: MEM
     andBool #rangeUInt(256, HEIGHT)
 PRE_MEM_COST: 672
 
-[get_deposit_root-success-loop-body]
+[get_deposit_root-success-loop-enter]
 pc: {PC_LOOPHEAD}
 word_stack: (HEIGHT => HEIGHT +Int 1) : {WORD_STACK_LOOP}
 local_mem: {LOCAL_MEM_LOOPHEAD} => NEW_MEM
@@ -315,7 +315,7 @@ local_mem: {LOCAL_MEM_LOOPHEAD} => NEW_MEM
     // conditions
     andBool HEIGHT =/=Int 32
 
-[get_deposit_root-success-loop-body-then]
+[get_deposit_root-success-loop-enter-then]
 NODE_NEW: #sha256(#buf(32, {BRANCH_HEIGHT}) ++ #buf(32, NODE))
 BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
 +requires:
@@ -324,7 +324,7 @@ BRANCH_HEIGHT: select(M, #hashedLocation({COMPILER}, {BRANCH}, HEIGHT))
 GAS_COST: 1350
 MEM_COST: 672
 
-[get_deposit_root-success-loop-body-else]
+[get_deposit_root-success-loop-enter-else]
 NODE_NEW: #sha256(#buf(32, NODE) ++ #buf(32, {ZERO_HASHES_HEIGHT}))
 ZERO_HASHES_HEIGHT: select(M, #hashedLocation({COMPILER}, {ZERO_HASHES}, HEIGHT))
 +requires:

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -545,21 +545,22 @@ memory_used: #symMem({MU_DATA} => {MU_ADD_EVEN}, .Set)
 [deposit-success-insert-loop]
 LOCAL_MEM_LOOPHEAD: MEM
     {VYPER_GENERATED_BOUNDS}
-    ; locals
+    ; locals - invariants
     [ 2784 := #buf(32, NODE) ]      /* node */
     [ 3328 := #buf(32, SIZE) ]      /* size */
     [ 3360 := #buf(32, HEIGHT) ]    /* height */
 +requires:
-    // conditions
-    andBool #range(0 <= HEIGHT <= 32)
+    // conditions - invariants
+    andBool HEIGHT <=Int 32
     // types
     andBool #rangeUInt(256, NODE)
     andBool #rangeUInt(256, SIZE)
+    andBool #rangeUInt(256, HEIGHT)
 
 [deposit-success-insert-loop-enter]
 +requires:
     // conditions
-    andBool HEIGHT <Int 32
+    andBool HEIGHT =/=Int 32
 
 [deposit-success-insert-loop-enter-then]
 k: #execute => #halt

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -288,17 +288,18 @@ MEM_COST: 544
 [get_deposit_root-success-loop]
 LOCAL_MEM_LOOPHEAD: MEM
     {VYPER_GENERATED_BOUNDS}
-    ; locals
+    ; locals - invariants
     [ 320 /* = 320 + 32 * 0 */ := #buf(32, 0) ]          /* zero_bytes32: bytes32 = 0x0 */
     [ 352 /* = 320 + 32 * 1 */ := #buf(32, NODE) ]       /* node: bytes32 */
     [ 384 /* = 320 + 32 * 2 */ := #buf(32, SIZE) ]       /* size: uint256 */
     [ 416 /* = 320 + 32 * 3 */ := #buf(32, HEIGHT) ]     /* height */
 +requires:
-    // conditions
-    andBool #range(0 <= HEIGHT <= 32)
+    // conditions - invariants
+    andBool HEIGHT <=Int 32
     // types
     andBool #rangeUInt(256, NODE)
     andBool #rangeUInt(256, SIZE)
+    andBool #rangeUInt(256, HEIGHT)
 
 [get_deposit_root-success-loop-body]
 pc: {PC_LOOPHEAD}
@@ -312,7 +313,7 @@ local_mem: {LOCAL_MEM_LOOPHEAD} => NEW_MEM
     andBool #range(NEW_MEM, 416, 32) ==K #buf(32, HEIGHT +Int 1)
 +requires:
     // conditions
-    andBool HEIGHT <Int 32
+    andBool HEIGHT =/=Int 32
 gas:         #symGas(G, 0 => {GAS_COST}, 0 => {GAS_COST}, .List, Cmem({SCHEDULE}, {MEMORY_USED}))
 memory_used: #symMem(672, .Set)
 

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -24,12 +24,10 @@ status_code: _ => _
 ; variables
 comment:
 schedule:       ISTANBUL
-call_stack:     CALL_STACK
 this:           THIS
 msg_sender:     MSG_SENDER
 call_value:     CALL_VALUE
 call_depth:     CALL_DEPTH
-coinbase:       COIN_BASE
 active_accounts:
 accounts:
 requires:

--- a/deposit/bytecode-verification/deposit-spec.ini
+++ b/deposit/bytecode-verification/deposit-spec.ini
@@ -105,7 +105,7 @@ LET_BINDINGS_OF_TO_LITTLE_ENDIAN_64_DEPOSIT_AMOUNT:
 [init]
 ; for create
 code: {INIT_CODE}
-call_data: .WordStack
+call_data: #buf(CALL_DATA_SIZE, CALL_DATA) /* The expected call_data is empty, but we want to ensure that any accidental or malicious garbage doesn't break the logic. */
 storage: .Map
 orig_storage: .Map
 

--- a/deposit/bytecode-verification/spec-tmpl.k
+++ b/deposit/bytecode-verification/spec-tmpl.k
@@ -2,15 +2,12 @@
 rule
 <kevm>
   <k> {K} </k>
-  <exit-code> 1 </exit-code>
   <mode> NORMAL </mode>
   <schedule> {SCHEDULE} </schedule>
   <ethereum>
     <evm>
       <output> {OUTPUT} </output>
       <statusCode> {STATUS_CODE} </statusCode>
-      <callStack> {CALL_STACK} </callStack>
-      <interimStates> _ </interimStates>
       <touchedAccounts> _ => _ </touchedAccounts>
       <callState>
         <program> #parseByteStack({CODE}) </program>
@@ -29,31 +26,11 @@ rule
         <callDepth> {CALL_DEPTH} </callDepth>
       </callState>
       <substate>
-        <selfDestruct> _ </selfDestruct>
         <log> {LOG} </log>
         <refund> {REFUND} </refund>
+        ...
       </substate>
-      <gasPrice> _ </gasPrice>
-      <origin> ORIGIN_ID </origin> // tx.origin
-      <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
-      <block>
-        <previousHash> _ </previousHash>
-        <ommersHash> _ </ommersHash>
-        <coinbase> {COINBASE} </coinbase> // block.coinbase
-        <stateRoot> _ </stateRoot>
-        <transactionsRoot> _ </transactionsRoot>
-        <receiptsRoot> _ </receiptsRoot>
-        <logsBloom> _ </logsBloom>
-        <difficulty> _ </difficulty>
-        <number> BLOCK_NUM </number> // block.number
-        <gasLimit> _ </gasLimit>
-        <gasUsed> _ </gasUsed>
-        <timestamp> NOW </timestamp> // now = block.timestamp
-        <extraData> _ </extraData>
-        <mixHash> _ </mixHash>
-        <blockNonce> _ </blockNonce>
-        <ommerBlockHeaders> _ </ommerBlockHeaders>
-      </block>
+      ...
     </evm>
     <network>
       <activeAccounts> {ACTIVE_ACCOUNTS} SetItem({THIS}) SetItem(2) SetItem(4) _:Set </activeAccounts>
@@ -87,16 +64,12 @@ rule
         {ACCOUNTS}
         ...
       </accounts>
-      <txOrder> _ </txOrder>
-      <txPending> _ </txPending>
-      <messages> _ </messages>
+      ...
     </network>
   </ethereum>
+  ...
 </kevm>
-  requires #rangeAddress(ORIGIN_ID)
-   // builtins
-   andBool #rangeUInt(256, NOW)
-   andBool #rangeUInt(128, BLOCK_NUM) // Solidity
+  requires true
    {REQUIRES}
   ensures true
    {ENSURES}


### PR DESCRIPTION
This further improves the specs.
- Now the init spec considers arbitrary accidental and/or malicious calldata garbage for security.
- The loop invariant regarding the loop index for both get_deposit_root and deposit is clarified.
- The gas/memory cost description is simplified to avoid duplication in the ini file.
- The unnecessary cells are omitted in the specification.
- And, some minor reorgs.